### PR TITLE
fix wpf demo bug: 退出房间后无法重新开启视频通话

### DIFF
--- a/Windows/WPFDemo/MainWindow.xaml.cs
+++ b/Windows/WPFDemo/MainWindow.xaml.cs
@@ -237,6 +237,10 @@ namespace TRTCWPFDemo
             this.Dispatcher.Invoke(new Action(() => {
                 if (result >= 0)
                 {
+                    // 开启本地音视频流
+                    mTRTCCloud.muteLocalAudio(false);
+                    mTRTCCloud.muteLocalVideo(false);
+                    
                     // 进房成功
                     mIsEnterSuccess = true;
                 }


### PR DESCRIPTION
exit room mute local audio and video, but enter room forget to reopen them