### PR TITLE
fix(TIM): 无法监听 IM_READY 状态

### DIFF
--- a/WXMini/components/trtc-room/trtc-room.js
+++ b/WXMini/components/trtc-room/trtc-room.js
@@ -1659,7 +1659,7 @@ Component({
     },
     _onIMReady(event) {
       console.log(TAG_NAME, 'IM.SDK_READY', event)
-      this._emitter.emit(EVENT.IM_SDK_READY, event)
+      this._emitter.emit(EVENT.IM_READY, event)
       const roomID = this.data.config.roomID
       // 查询群组是否存在
       this._searchGroup({ roomID }).then((res) => {


### PR DESCRIPTION
SDK 中事件 `IM_READY` 所对应的名字错误。