### PR TITLE
解决TXVoiceRoomService退出登录状态不正确，以及没有回调的问题

### DIFF
--- a/iOS/TRTCScenesDemo/TXLiteAVDemo/TRTCVoiceRoomDemo/model/Impl/voiceroom/TXVoiceRoomService.m
+++ b/iOS/TRTCScenesDemo/TXLiteAVDemo/TRTCVoiceRoomDemo/model/Impl/voiceroom/TXVoiceRoomService.m
@@ -115,8 +115,14 @@
         if (!self) {
             return;
         }
+        self.isLogin = NO;
+        if (callback) {
+            callback(0, @"log out IM SDK success");
+        }
     } fail:^(int code, NSString *desc) {
-        
+        if (callback) {
+            callback(VOICE_ROOM_SERVICE_CODE_ERROR, @"log out IM SDK failed");
+        }
     }];
 }
 


### PR DESCRIPTION
isLogin的状态在退出登录时，没有设置为NO。logout时的callback没有回调