### PR TITLE
更新QTDemo配置文件及TRTC命名空间的引用，适配最新的TRTC SDK编译。

### DIFF
--- a/Mac/QTDemo/QTDemo.pro
+++ b/Mac/QTDemo/QTDemo.pro
@@ -164,20 +164,61 @@ DEPENDPATH += $${SOURCE_PATHS}
 
 QMAKE_INFO_PLIST += Info.plist
 
+# 添加TXLiteAVSDK_TRTC_Mac.framework头文件
+INCLUDEPATH += $$PWD/../SDK/TXLiteAVSDK_TRTC_Mac.framework/Headers/cpp_interface
+INCLUDEPATH += $$PWD/../SDK/TXLiteAVSDK_TRTC_Mac.framework/Headers
+
 # 添加库依赖
-LIBS += "-F$$PWD/src/Util/mac/usersig"
 LIBS += "-F$$PWD/../SDK"
 LIBS += -framework TXLiteAVSDK_TRTC_Mac
+
+# 引用的系统库
+QMAKE_CXXFLAGS += -x objective-c++
 LIBS += -framework Accelerate
 LIBS += -framework AudioUnit
 LIBS += -lbz2
 LIBS += -lresolv
-#without c++11 & AppKit library compiler can't solve address for symbols
 LIBS += -framework AppKit
+LIBS += -framework Foundation
+LIBS += -framework CoreFoundation
+LIBS += -framework Cocoa
+LIBS += -framework Security
+LIBS += -framework SystemConfiguration
+LIBS += -framework JavaScriptCore
+LIBS += -framework CoreMedia
+LIBS += -framework CoreAudio
+LIBS += -framework CoreVideo
+LIBS += -framework CoreImage
+LIBS += -framework AVFoundation
+LIBS += -framework AudioToolbox
+LIBS += -framework VideoToolbox
+LIBS += -framework MetalKit
+LIBS += -framework Metal
+LIBS += -framework CoreTelephony
+LIBS += -framework CoreGraphics
+LIBS += -framework OpenGL
+LIBS += -framework OpenAL
+LIBS += -framework QuartzCore
+LIBS += -lz
+LIBS += -ObjC
 
-# 添加TXLiteAVSDK_TRTC_Mac.framework头文件
-INCLUDEPATH += $$PWD/../SDK/TXLiteAVSDK_TRTC_Mac.framework/Headers/cpp_interface \
-               $$PWD/../SDK/TXLiteAVSDK_TRTC_Mac.framework/Headers
+# TXFFmpeg库的使用
+LIBS += -F$$PWD/../SDK/TXFFmpeg.xcframework/macos-arm64_x86_64
+LIBS += -framework TXFFmpeg
+TXFFmpeg_FRAMEWORK.files = $$PWD/../SDK/TXFFmpeg.xcframework/macos-arm64_x86_64/TXFFmpeg.framework
+TXFFmpeg_FRAMEWORK.path = /Contents/Frameworks
+QMAKE_BUNDLE_DATA += TXFFmpeg_FRAMEWORK
+
+# TXSoundTouch库的使用
+LIBS += -F$$PWD/../SDK/TXSoundTouch.xcframework/macos-arm64_x86_64
+LIBS += -framework TXSoundTouch
+TXSoundTouch_FRAMEWORK.files = $$PWD/../SDK/TXSoundTouch.xcframework/macos-arm64_x86_64/TXSoundTouch.framework
+TXSoundTouch_FRAMEWORK.path = /Contents/Frameworks
+QMAKE_BUNDLE_DATA += TXSoundTouch_FRAMEWORK
+
+# 运行时库路径rpath的添加
+QMAKE_LFLAGS += -Wl -ObjC
+QMAKE_LFLAGS += -Wl,-rpath,@executable_path/../Frameworks/
 
 macx: LIBS += -L$$PWD/src/Util/mac/usersig/ -lTXLiteAVTestUserSig
 macx: PRE_TARGETDEPS += $$PWD/src/Util/mac/usersig/libTXLiteAVTestUserSig.a
@@ -187,8 +228,7 @@ CONFIG += console
 INCLUDEPATH += $$PWD/src/Util/mac/usersig/include
 DEPENDPATH += $$PWD/src/Util/mac/usersig/include
 
-DISTFILES += \
-    src/Util/mac/usersig/libTXLiteAVTestUserSig.a
+DISTFILES += $$PWD/src/Util/mac/usersig/libTXLiteAVTestUserSig.a
 
 SOURCES += \
     $$PWD/src/Util/mac/cdnplayer/tx_liveplayer_proxy.mm

--- a/Mac/QTDemo/src/TestAudioDetect/test_audio_detect.cpp
+++ b/Mac/QTDemo/src/TestAudioDetect/test_audio_detect.cpp
@@ -88,17 +88,17 @@ void TestAudioDetect::refreshMicDevices()
     }
     //microphone
     qvector_device_info_mic_.clear();
-    trtc::ITXDeviceCollection *device_collection_microphone = tx_device_manager_->getDevicesList(trtc::TXMediaDeviceType::TXMediaDeviceTypeMic);
+    liteav::ITXDeviceCollection *device_collection_microphone = tx_device_manager_->getDevicesList(liteav::TXMediaDeviceType::TXMediaDeviceTypeMic);
     uint32_t microphone_device_count = device_collection_microphone->getCount();
     if(microphone_device_count != 0) {
 
-        trtc::ITXDeviceInfo *current_microphone_device = tx_device_manager_->getCurrentDevice(trtc::TXMediaDeviceType::TXMediaDeviceTypeMic);
+        liteav::ITXDeviceInfo *current_microphone_device = tx_device_manager_->getCurrentDevice(liteav::TXMediaDeviceType::TXMediaDeviceTypeMic);
         ui_audio_test_->comboBoxMic->clear();
         uint32_t current_selected_microphone_device_index = 0;
 
         for(uint32_t index = 0; index < microphone_device_count; index++) {
 
-            const DeviceInfoItem item = DeviceInfoItem(device_collection_microphone->getDeviceName(index), device_collection_microphone->getDevicePID(index), trtc::TXMediaDeviceType::TXMediaDeviceTypeMic);
+            const DeviceInfoItem item = DeviceInfoItem(device_collection_microphone->getDeviceName(index), device_collection_microphone->getDevicePID(index), liteav::TXMediaDeviceType::TXMediaDeviceTypeMic);
             qvector_device_info_mic_.append(item);
             ui_audio_test_->comboBoxMic->addItem(QString::fromStdString(item.device_name_));
 
@@ -119,17 +119,17 @@ void TestAudioDetect::refreshSpeakerDevices()
     }
     //loudspeaker
     qvector_device_info_speaker_.clear();
-    trtc::ITXDeviceCollection *device_collection_loudspeaker = tx_device_manager_->getDevicesList(trtc::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
+    liteav::ITXDeviceCollection *device_collection_loudspeaker = tx_device_manager_->getDevicesList(liteav::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
     uint32_t loudspeaker_device_count = device_collection_loudspeaker->getCount();
     if(loudspeaker_device_count != 0) {
 
-        trtc::ITXDeviceInfo *current_loudspeaker_device = tx_device_manager_->getCurrentDevice(trtc::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
+        liteav::ITXDeviceInfo *current_loudspeaker_device = tx_device_manager_->getCurrentDevice(liteav::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
         ui_audio_test_->comboBoxSpeaker->clear();
         uint32_t current_selected_loudspeaker_device_index = 0;
 
         for(uint32_t index = 0; index < loudspeaker_device_count; index++) {
 
-            const DeviceInfoItem item = DeviceInfoItem(device_collection_loudspeaker->getDeviceName(index), device_collection_loudspeaker->getDevicePID(index), trtc::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
+            const DeviceInfoItem item = DeviceInfoItem(device_collection_loudspeaker->getDeviceName(index), device_collection_loudspeaker->getDevicePID(index), liteav::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
             qvector_device_info_speaker_.append(item);
             ui_audio_test_->comboBoxSpeaker->addItem(QString::fromStdString(item.device_name_));
 
@@ -161,12 +161,12 @@ void TestAudioDetect::on_comboBoxSpeaker_currentIndexChanged(int index)
 
 void TestAudioDetect::on_sliderSpeakerVolume_valueChanged(int value)
 {
-    tx_device_manager_->setCurrentDeviceVolume(trtc::TXMediaDeviceTypeSpeaker, (uint32_t)value);
+    tx_device_manager_->setCurrentDeviceVolume(liteav::TXMediaDeviceTypeSpeaker, (uint32_t)value);
 }
 
 void TestAudioDetect::on_sliderMicVolume_valueChanged(int value)
 {
-    tx_device_manager_->setCurrentDeviceVolume(trtc::TXMediaDeviceTypeMic, (uint32_t)value);
+    tx_device_manager_->setCurrentDeviceVolume(liteav::TXMediaDeviceTypeMic, (uint32_t)value);
 }
 
 void TestAudioDetect::on_pushButtonStartMicTest_clicked(bool checked)

--- a/Mac/QTDemo/src/TestAudioDetect/test_audio_detect.h
+++ b/Mac/QTDemo/src/TestAudioDetect/test_audio_detect.h
@@ -87,10 +87,10 @@ private:
     struct DeviceInfoItem {
     std::string device_name_;
     std::string device_id_;
-    trtc::TXMediaDeviceType device_type_;
+    liteav::TXMediaDeviceType device_type_;
 
     DeviceInfoItem() {}
-    DeviceInfoItem(std::string device_name, std::string device_id, trtc::TXMediaDeviceType device_type) :
+    DeviceInfoItem(std::string device_name, std::string device_id, liteav::TXMediaDeviceType device_type) :
         device_name_(device_name), device_id_(device_id), device_type_(device_type) {}
     };
 
@@ -98,7 +98,7 @@ private:
     bool device_info_ready_ = false;
     QTemporaryDir qtemp_dir_;
     std::unique_ptr<Ui::TestAudioDetectDialog> ui_audio_test_;
-    trtc::ITXDeviceManager *tx_device_manager_;
+    liteav::ITXDeviceManager *tx_device_manager_;
     QVector<DeviceInfoItem> qvector_device_info_mic_;
     QVector<DeviceInfoItem> qvector_device_info_speaker_;
     bool mic_test_started_ = false;

--- a/Mac/QTDemo/src/TestAudioRecord/test_audio_record.cpp
+++ b/Mac/QTDemo/src/TestAudioRecord/test_audio_record.cpp
@@ -33,7 +33,7 @@ void TestAudioRecord::startAudioRecording()
         QMessageBox::warning(NULL, "Failed to start recording", "Enter a valid path.");
         return;
     }
-    trtc::TRTCAudioRecordingParams params;
+    liteav::TRTCAudioRecordingParams params;
     QFileInfo fileInfo(file_path);
     std::string temp = fileInfo.absoluteFilePath().toStdString();
     last_record_file_path = QString(temp.c_str());

--- a/Mac/QTDemo/src/TestAudioRecord/test_audio_record.h
+++ b/Mac/QTDemo/src/TestAudioRecord/test_audio_record.h
@@ -79,7 +79,7 @@ private:
     QString last_record_file_path;
 
     std::unique_ptr<Ui::TestAudioRecordDialog> ui_audio_record_;
-    trtc::ITRTCCloud *trtccloud_;
+    liteav::ITRTCCloud *trtccloud_;
     QTimer *qtimer_ = new QTimer();
 
 };

--- a/Mac/QTDemo/src/TestAudioSetting/test_audio_setting.cpp
+++ b/Mac/QTDemo/src/TestAudioSetting/test_audio_setting.cpp
@@ -49,12 +49,12 @@ void TestAudioSetting::on_checkBoxApplicationMute_stateChanged(int state)
 
 void TestAudioSetting::on_horizontalSliderCurrentDeviceVolume_valueChanged(int value)
 {
-    tx_device_manager_->setCurrentDeviceVolume(trtc::TRTCDeviceType::TXMediaDeviceTypeSpeaker, value);
+    tx_device_manager_->setCurrentDeviceVolume(liteav::TRTCDeviceType::TXMediaDeviceTypeSpeaker, value);
 }
 
 void TestAudioSetting::on_checkBoxCurrentDeviceMute_stateChanged(int state)
 {
-    tx_device_manager_->setCurrentDeviceMute(trtc::TRTCDeviceType::TXMediaDeviceTypeSpeaker, state == Qt::CheckState::Checked);
+    tx_device_manager_->setCurrentDeviceMute(liteav::TRTCDeviceType::TXMediaDeviceTypeSpeaker, state == Qt::CheckState::Checked);
 }
 
 void TestAudioSetting::on_horizontalSliderAudioCaptureVolume_valueChanged(int value)
@@ -94,8 +94,8 @@ void TestAudioSetting::initUIStatus()
     ui_audio_setting_->horizontalSliderSystemAudioLoopbackVolume->setValue(100);
     ui_audio_setting_->checkBoxSytemAudioLoopbak->setChecked(false);
 
-    ui_audio_setting_->horizontalSliderCurrentDeviceVolume->setValue(tx_device_manager_->getCurrentDeviceVolume(trtc::TXMediaDeviceType::TXMediaDeviceTypeSpeaker));
-    ui_audio_setting_->checkBoxCurrentDeviceMute->setChecked(tx_device_manager_->getCurrentDeviceMute(trtc::TRTCDeviceType::TXMediaDeviceTypeSpeaker));
+    ui_audio_setting_->horizontalSliderCurrentDeviceVolume->setValue(tx_device_manager_->getCurrentDeviceVolume(liteav::TXMediaDeviceType::TXMediaDeviceTypeSpeaker));
+    ui_audio_setting_->checkBoxCurrentDeviceMute->setChecked(tx_device_manager_->getCurrentDeviceMute(liteav::TRTCDeviceType::TXMediaDeviceTypeSpeaker));
     ui_audio_setting_->horizontalSliderAudioCaptureVolume->setValue(trtccloud_->getAudioCaptureVolume());
     updateRemoteUsersList();
 }

--- a/Mac/QTDemo/src/TestAudioSetting/test_audio_setting.h
+++ b/Mac/QTDemo/src/TestAudioSetting/test_audio_setting.h
@@ -80,9 +80,9 @@ private:
 
 private:
     std::unique_ptr<Ui::TestAudioSettingDialog> ui_audio_setting_;
-    trtc::ITRTCCloud *trtccloud_;
-    trtc::ITXDeviceManager *tx_device_manager_;
-    trtc::ITXAudioEffectManager *tx_audio_effect_manager_;
+    liteav::ITRTCCloud *trtccloud_;
+    liteav::ITXDeviceManager *tx_device_manager_;
+    liteav::ITXAudioEffectManager *tx_audio_effect_manager_;
     QString current_selected_remote_user_id_;
 
 };

--- a/Mac/QTDemo/src/TestBaseScene/test_base_scene.cpp
+++ b/Mac/QTDemo/src/TestBaseScene/test_base_scene.cpp
@@ -18,7 +18,7 @@ TestBaseScene::~TestBaseScene() {
     getTRTCShareInstance()->removeCallback(this);
 }
 
-void TestBaseScene::enterRoom(uint32_t roomId, std::string userId, trtc::TRTCAppScene appScene, trtc::TRTCRoleType roleType) {
+void TestBaseScene::enterRoom(uint32_t roomId, std::string userId, liteav::TRTCAppScene appScene, liteav::TRTCRoleType roleType) {
 
     room_id_ = roomId;
     user_id_ = userId;
@@ -31,7 +31,7 @@ void TestBaseScene::enterRoom(uint32_t roomId, std::string userId, trtc::TRTCApp
     streamid_os << SDKAppID << "_" << room_id_ << "_" << user_id_ << "_" << "main";
     stream_id_ = streamid_os.str();
 
-    trtc::TRTCParams params;
+    liteav::TRTCParams params;
     params.sdkAppId = SDKAppID;
     params.userId = user_id_.c_str();
     /** @note: 请不要将如下代码发布到您的线上正式版本的 App 中，原因如下：
@@ -63,7 +63,7 @@ void TestBaseScene::exitRoom() {
     getTRTCShareInstance()->exitRoom();
 }
 
-void TestBaseScene::switchRole(trtc::TRTCRoleType roleType){
+void TestBaseScene::switchRole(liteav::TRTCRoleType roleType){
     getTRTCShareInstance()->switchRole(roleType);
 }
 
@@ -76,11 +76,11 @@ void TestBaseScene::onEnterRoom(int result) {
 
         // Enable audio
         getTRTCShareInstance()->enableAudioVolumeEvaluation(300); // Effective before the calling of startLocalAudio
-        getTRTCShareInstance()->startLocalAudio(trtc::TRTCAudioQualityDefault);
+        getTRTCShareInstance()->startLocalAudio(liteav::TRTCAudioQualityDefault);
 
         // Enable video
-        if(app_scene_ == trtc::TRTCAppScene::TRTCAppSceneVideoCall || app_scene_ == trtc::TRTCAppScene::TRTCAppSceneLIVE){
-            getTRTCShareInstance()->setBeautyStyle(trtc::TRTCBeautyStyleSmooth, 6, 6, 6);
+        if(app_scene_ == liteav::TRTCAppScene::TRTCAppSceneVideoCall || app_scene_ == liteav::TRTCAppScene::TRTCAppSceneLIVE){
+            getTRTCShareInstance()->setBeautyStyle(liteav::TRTCBeautyStyleSmooth, 6, 6, 6);
             getTRTCShareInstance()->startLocalPreview(test_user_video_group_->getLocalVideoTxView());
         }
 

--- a/Mac/QTDemo/src/TestBaseScene/test_base_scene.h
+++ b/Mac/QTDemo/src/TestBaseScene/test_base_scene.h
@@ -50,9 +50,9 @@ public:
     explicit TestBaseScene(std::shared_ptr<TestUserVideoGroup> testUserVideoGroup);
     ~TestBaseScene();
 
-    void enterRoom(uint32_t roomId, std::string userId, trtc::TRTCAppScene appScene, trtc::TRTCRoleType roleType = trtc::TRTCRoleType::TRTCRoleAnchor);
+    void enterRoom(uint32_t roomId, std::string userId, liteav::TRTCAppScene appScene, liteav::TRTCRoleType roleType = liteav::TRTCRoleType::TRTCRoleAnchor);
     void exitRoom();
-    void switchRole(trtc::TRTCRoleType roleType);
+    void switchRole(liteav::TRTCRoleType roleType);
 
     //============= ITRTCCloudCallback start =================//
     void onEnterRoom(int result);
@@ -64,8 +64,8 @@ private:
     std::shared_ptr<TestUserVideoGroup> test_user_video_group_;
     uint32_t room_id_;
     std::string user_id_;
-    trtc::TRTCAppScene app_scene_;
-    trtc::TRTCRoleType role_type_;
+    liteav::TRTCAppScene app_scene_;
+    liteav::TRTCRoleType role_type_;
     std::string stream_id_;
 
 };

--- a/Mac/QTDemo/src/TestBaseScene/test_user_screen_share_view.cpp
+++ b/Mac/QTDemo/src/TestBaseScene/test_user_screen_share_view.cpp
@@ -14,7 +14,7 @@ TestUserScreenShareView::~TestUserScreenShareView()
 }
 
 void TestUserScreenShareView::stopUserScreenShare(std::string userId){
-    getTRTCShareInstance()->stopRemoteView(userId.c_str(),trtc::TRTCVideoStreamTypeSub);
+    getTRTCShareInstance()->stopRemoteView(userId.c_str(),liteav::TRTCVideoStreamTypeSub);
 }
 
 void TestUserScreenShareView::retranslateUi() {

--- a/Mac/QTDemo/src/TestBaseScene/test_user_video_group.cpp
+++ b/Mac/QTDemo/src/TestBaseScene/test_user_video_group.cpp
@@ -18,8 +18,8 @@ TestUserVideoGroup::~TestUserVideoGroup() {
     visible_user_video_items_.clear();
 }
 
-void TestUserVideoGroup::setNetworkQosParam(trtc::TRTCVideoQosPreference preference, trtc::TRTCQosControlMode controlMode) {
-    trtc::TRTCNetworkQosParam param;
+void TestUserVideoGroup::setNetworkQosParam(liteav::TRTCVideoQosPreference preference, liteav::TRTCQosControlMode controlMode) {
+    liteav::TRTCNetworkQosParam param;
     param.controlMode = controlMode;
     param.preference = preference;
     getTRTCShareInstance()->setNetworkQosParam(param);
@@ -80,27 +80,27 @@ void TestUserVideoGroup::onUserSubStreamAvailable(const char *userId, bool avail
 {
     if (available) {
         current_screen_sharing_user_id_ = userId;
-        getTRTCShareInstance()->startRemoteView(userId, trtc::TRTCVideoStreamTypeSub, (trtc::TXView)(user_screen_share_view_->winId()));
+        getTRTCShareInstance()->startRemoteView(userId, liteav::TRTCVideoStreamTypeSub, (liteav::TXView)(user_screen_share_view_->winId()));
         user_screen_share_view_->setWindowTitle(QString("screen share from userId: %1").arg(userId));
         user_screen_share_view_->show();
         user_screen_share_view_->raise();
         ui_video_group_->pushButtonShowRemoteScreenShare->setEnabled(true);
     } else {
-        getTRTCShareInstance()->stopRemoteView(userId, trtc::TRTCVideoStreamTypeSub);
+        getTRTCShareInstance()->stopRemoteView(userId, liteav::TRTCVideoStreamTypeSub);
         user_screen_share_view_->close();
         current_screen_sharing_user_id_ = "";
         ui_video_group_->pushButtonShowRemoteScreenShare->setEnabled(false);
     }
 }
 
-void TestUserVideoGroup::onUserVoiceVolume(trtc::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) {
+void TestUserVideoGroup::onUserVoiceVolume(liteav::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) {
     handleUserVolume(userVolumes, userVolumesCount, totalVolume);
 }
 //============= ITRTCCloudCallback end ==================//
 
-trtc::TXView TestUserVideoGroup::getLocalVideoTxView() {
+liteav::TXView TestUserVideoGroup::getLocalVideoTxView() {
     if (visible_user_video_items_.size() > 0 && visible_user_video_items_[0]->getViewType() == TEST_VIDEO_ITEM::LocalView) {
-        return reinterpret_cast<trtc::TXView>(visible_user_video_items_[0]->getVideoWId());
+        return reinterpret_cast<liteav::TXView>(visible_user_video_items_[0]->getVideoWId());
     }
     return NULL;
 }
@@ -110,7 +110,7 @@ void TestUserVideoGroup::setMainRoomId(int mainRoomId)
     main_room_id_ = mainRoomId;
 }
 
-void TestUserVideoGroup::addUserVideoItem(trtc::ITRTCCloud* cloud,int roomId,const char *userId, const TEST_VIDEO_ITEM::ViewItemType type){
+void TestUserVideoGroup::addUserVideoItem(liteav::ITRTCCloud* cloud,int roomId,const char *userId, const TEST_VIDEO_ITEM::ViewItemType type){
     std::vector<TestUserVideoItem*>::const_iterator iterator = visible_user_video_items_.begin();
 
     while (iterator != visible_user_video_items_.end()) {
@@ -199,45 +199,45 @@ void TestUserVideoGroup::removeAllUsers()
 }
 
 void TestUserVideoGroup::on_networkModeCb_currentIndexChanged(int index) {
-    trtc::TRTCVideoQosPreference preference = trtc::TRTCVideoQosPreference::TRTCVideoQosPreferenceSmooth;
+    liteav::TRTCVideoQosPreference preference = liteav::TRTCVideoQosPreference::TRTCVideoQosPreferenceSmooth;
     switch (index) {
     case 0:
-        preference = trtc::TRTCVideoQosPreference::TRTCVideoQosPreferenceClear;
+        preference = liteav::TRTCVideoQosPreference::TRTCVideoQosPreferenceClear;
         break;
     case 1:
-        preference = trtc::TRTCVideoQosPreference::TRTCVideoQosPreferenceSmooth;
+        preference = liteav::TRTCVideoQosPreference::TRTCVideoQosPreferenceSmooth;
         break;
     }
 
-    trtc::TRTCQosControlMode control_mode = trtc::TRTCQosControlMode::TRTCQosControlModeServer;
+    liteav::TRTCQosControlMode control_mode = liteav::TRTCQosControlMode::TRTCQosControlModeServer;
     setNetworkQosParam(preference, control_mode);
 }
 
 void TestUserVideoGroup::initView() {
     addUserVideoItem(getTRTCShareInstance(),main_room_id_,"myself", TEST_VIDEO_ITEM::LocalView);
-    trtc::TRTCVideoQosPreference preference = trtc::TRTCVideoQosPreference::TRTCVideoQosPreferenceSmooth;
+    liteav::TRTCVideoQosPreference preference = liteav::TRTCVideoQosPreference::TRTCVideoQosPreferenceSmooth;
     int index = ui_video_group_->networkModeCb->currentIndex();
     switch (index) {
     case 0:
-        preference = trtc::TRTCVideoQosPreference::TRTCVideoQosPreferenceClear;
+        preference = liteav::TRTCVideoQosPreference::TRTCVideoQosPreferenceClear;
         break;
     case 1:
-        preference = trtc::TRTCVideoQosPreference::TRTCVideoQosPreferenceSmooth;
+        preference = liteav::TRTCVideoQosPreference::TRTCVideoQosPreferenceSmooth;
         break;
     }
     ui_video_group_->checkBoxVolumeEvaluation->setChecked(true);
     ui_video_group_->muteAllRemoteAudioCb->setChecked(false);
     ui_video_group_->muteAllRemoteVideoCb->setChecked(false);
-    trtc::TRTCQosControlMode control_mode = trtc::TRTCQosControlMode::TRTCQosControlModeServer;
+    liteav::TRTCQosControlMode control_mode = liteav::TRTCQosControlMode::TRTCQosControlModeServer;
     setNetworkQosParam(preference, control_mode);
 }
 
-void TestUserVideoGroup::handleUserVideoAvailable(trtc::ITRTCCloud* cloud, int roomId, const char* userId, bool available)
+void TestUserVideoGroup::handleUserVideoAvailable(liteav::ITRTCCloud* cloud, int roomId, const char* userId, bool available)
 {
     for(std::vector<TestUserVideoItem*>::const_iterator iterator = visible_user_video_items_.begin(); iterator != visible_user_video_items_.end(); iterator++) {
         if(std::strcmp(userId, (*iterator)->getUserId().c_str()) == 0 && roomId == (*iterator)->getRoomId()) {
             if(available && cloud != nullptr) {
-                cloud->startRemoteView(userId, trtc::TRTCVideoStreamType::TRTCVideoStreamTypeBig, reinterpret_cast<trtc::TXView>((*iterator)->getVideoWId()));
+                cloud->startRemoteView(userId, liteav::TRTCVideoStreamType::TRTCVideoStreamTypeBig, reinterpret_cast<liteav::TXView>((*iterator)->getVideoWId()));
             }
             bool mute_all_remote_video = ui_video_group_->muteAllRemoteVideoCb->isChecked();
             (*iterator)->updateAVAvailableStatus(available, mute_all_remote_video, TEST_VIDEO_ITEM::MuteVideo);
@@ -284,7 +284,7 @@ void TestUserVideoGroup::on_pushButtonShowRemoteScreenShare_clicked()
     if(!current_screen_sharing_user_id_.isEmpty() && !user_screen_share_view_->isVisible()) {
         std::string user_id = current_screen_sharing_user_id_.toStdString();
         user_screen_share_view_->stopUserScreenShare(user_id);
-        getTRTCShareInstance()->startRemoteView(user_id.c_str(), trtc::TRTCVideoStreamTypeSub, (trtc::TXView)(user_screen_share_view_->winId()));
+        getTRTCShareInstance()->startRemoteView(user_id.c_str(), liteav::TRTCVideoStreamTypeSub, (liteav::TXView)(user_screen_share_view_->winId()));
         user_screen_share_view_->show();
         user_screen_share_view_->raise();
     }
@@ -320,7 +320,7 @@ void TestUserVideoGroup::changeEvent(QEvent* event) {
     QWidget::changeEvent(event);
 }
 
-void TestUserVideoGroup::onSubRoomUserEnterRoom(trtc::ITRTCCloud* subCloud,int roomId, std::string userId){
+void TestUserVideoGroup::onSubRoomUserEnterRoom(liteav::ITRTCCloud* subCloud,int roomId, std::string userId){
     addUserVideoItem(subCloud,roomId,userId.c_str(),TEST_VIDEO_ITEM::RemoteView);
 }
 
@@ -328,7 +328,7 @@ void TestUserVideoGroup::onSubRoomUserLeaveRoom(int roomId, std::string userId){
     removeUserVideoItem(roomId,userId.c_str());
 }
 
-void TestUserVideoGroup::onSubRoomUserVideoAvailable(trtc::ITRTCCloud* subCloud, int roomId, std::string userId, bool available)
+void TestUserVideoGroup::onSubRoomUserVideoAvailable(liteav::ITRTCCloud* subCloud, int roomId, std::string userId, bool available)
 {
     const char* user_id = userId.c_str();
     handleUserVideoAvailable(subCloud, roomId, user_id, available);
@@ -360,7 +360,7 @@ void TestUserVideoGroup::onSubRoomExit(int roomId){
     }
 }
 
-void TestUserVideoGroup::handleUserVolume(trtc::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) {
+void TestUserVideoGroup::handleUserVolume(liteav::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) {
     for (auto video_item : visible_user_video_items_) {
         for (uint32_t user_volums_index = 0; user_volums_index < userVolumesCount; user_volums_index++) {
             auto user_volum_item = userVolumes + user_volums_index;

--- a/Mac/QTDemo/src/TestBaseScene/test_user_video_group.h
+++ b/Mac/QTDemo/src/TestBaseScene/test_user_video_group.h
@@ -61,7 +61,7 @@ public:
     ~TestUserVideoGroup();
 
 private:
-    void setNetworkQosParam(trtc::TRTCVideoQosPreference preference, trtc::TRTCQosControlMode controlMode);
+    void setNetworkQosParam(liteav::TRTCVideoQosPreference preference, liteav::TRTCQosControlMode controlMode);
     void muteAllRemoteVideoStreams(bool mute);
     void muteAllRemoteAudio(bool mute);
     void showDebugView(bool show);
@@ -72,7 +72,7 @@ private:
     void onUserVideoAvailable(const char* userId, bool available) override;
     void onUserAudioAvailable(const char* userId, bool available) override;
     void onUserSubStreamAvailable(const char *userId, bool available) override;
-    void onUserVoiceVolume(trtc::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) override;
+    void onUserVoiceVolume(liteav::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) override;
     //============= ITRTCCloudCallback end =================//
 
 signals:
@@ -97,24 +97,24 @@ public:
     void changeEvent(QEvent* event);
 
     void setMainRoomId(int mainRoomId);
-    void addUserVideoItem(trtc::ITRTCCloud* cloud,int roomId,const char *userId,const TEST_VIDEO_ITEM::ViewItemType type);
-    void onSubRoomUserEnterRoom(trtc::ITRTCCloud* subCloud,int roomId,std::string userId);
+    void addUserVideoItem(liteav::ITRTCCloud* cloud,int roomId,const char *userId,const TEST_VIDEO_ITEM::ViewItemType type);
+    void onSubRoomUserEnterRoom(liteav::ITRTCCloud* subCloud,int roomId,std::string userId);
     void onSubRoomUserLeaveRoom(int roomId,std::string userId);
-    void onSubRoomUserVideoAvailable(trtc::ITRTCCloud*, int roomId, std::string userId, bool available);
+    void onSubRoomUserVideoAvailable(liteav::ITRTCCloud*, int roomId, std::string userId, bool available);
     void onSubRoomUserAudioAvailable(int roomId, std::string userId, bool available);
     void onSubRoomExit(int roomId);
-    void handleUserVolume(trtc::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume);
+    void handleUserVolume(liteav::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume);
 
 private:
     void removeUserVideoItem(int roomId,const char *userId);
     void removeAllUsers();
     void initView();
-    void handleUserVideoAvailable(trtc::ITRTCCloud* cloud, int roomId, const char* userId, bool available);
+    void handleUserVideoAvailable(liteav::ITRTCCloud* cloud, int roomId, const char* userId, bool available);
     void handleUserAudioAvailable(int roomId, const char* userId, bool available);
     void updateRemoteViewsMuteStatus(bool status, TEST_VIDEO_ITEM::MuteAllType muteType);
 
 public:
-    trtc::TXView getLocalVideoTxView();
+    liteav::TXView getLocalVideoTxView();
     static const int ROW_NUM = 3;
 
 private:

--- a/Mac/QTDemo/src/TestBaseScene/test_user_video_item.cpp
+++ b/Mac/QTDemo/src/TestBaseScene/test_user_video_item.cpp
@@ -1,6 +1,6 @@
 ﻿#include "test_user_video_item.h"
 
-TestUserVideoItem::TestUserVideoItem(QWidget * parent,trtc::ITRTCCloud* cloud, int roomid, std::string userid, TEST_VIDEO_ITEM::ViewItemType type)
+TestUserVideoItem::TestUserVideoItem(QWidget * parent,liteav::ITRTCCloud* cloud, int roomid, std::string userid, TEST_VIDEO_ITEM::ViewItemType type)
     :QWidget(parent), ui_video_item_(new Ui::TestUserVideoItem), viewtype_(type) {
     this->room_id_ = roomid;
     this->user_id_ = userid;
@@ -45,7 +45,7 @@ void TestUserVideoItem::muteVideo(bool mute) {
 }
 
 void TestUserVideoItem::setRenderParams() {
-    trtc::TRTCRenderParams param;
+    liteav::TRTCRenderParams param;
     param.rotation = rotation_;
     param.fillMode = fill_mode_;
     param.mirrorType = mirror_type_;
@@ -56,7 +56,7 @@ void TestUserVideoItem::setRenderParams() {
     }
 
     if (viewtype_ == TEST_VIDEO_ITEM::RemoteView) {
-        trtccloud_->setRemoteRenderParams(user_id_.c_str(), trtc::TRTCVideoStreamTypeBig, param);
+        trtccloud_->setRemoteRenderParams(user_id_.c_str(), liteav::TRTCVideoStreamTypeBig, param);
         return;
     }
 
@@ -143,12 +143,12 @@ void TestUserVideoItem::on_videoMuteBt_clicked() {
 
 void TestUserVideoItem::on_fitScreenBt_clicked() {
     QString fill_mode_bt_stylesheet;
-    if (fill_mode_ == trtc::TRTCVideoFillMode_Fill) {
-        fill_mode_ = trtc::TRTCVideoFillMode_Fit;
+    if (fill_mode_ == liteav::TRTCVideoFillMode_Fill) {
+        fill_mode_ = liteav::TRTCVideoFillMode_Fit;
         fill_mode_bt_stylesheet = "QPushButton{border-image: url(:/switch/image/switch/fit_open.png);}";
 
-    } else if (fill_mode_ == trtc::TRTCVideoFillMode_Fit) {
-        fill_mode_ = trtc::TRTCVideoFillMode_Fill;
+    } else if (fill_mode_ == liteav::TRTCVideoFillMode_Fit) {
+        fill_mode_ = liteav::TRTCVideoFillMode_Fill;
         fill_mode_bt_stylesheet = "QPushButton{border-image: url(:/switch/image/switch/fill_open.png);}";
     }
     ui_video_item_->fitScreenBt->setStyleSheet(fill_mode_bt_stylesheet);
@@ -157,11 +157,11 @@ void TestUserVideoItem::on_fitScreenBt_clicked() {
 
 void TestUserVideoItem::on_preSmallVideoBt_clicked() {
     QString small_pre__bt_stylesheet;
-    if (video_stream_type_ == trtc::TRTCVideoStreamTypeBig) {
-        video_stream_type_ = trtc::TRTCVideoStreamTypeSmall;
+    if (video_stream_type_ == liteav::TRTCVideoStreamTypeBig) {
+        video_stream_type_ = liteav::TRTCVideoStreamTypeSmall;
         small_pre__bt_stylesheet = "QPushButton{border-image: url(:/switch/image/switch/small_open.png);}";
-    } else if (video_stream_type_ == trtc::TRTCVideoStreamTypeSmall) {
-        video_stream_type_ = trtc::TRTCVideoStreamTypeBig;
+    } else if (video_stream_type_ == liteav::TRTCVideoStreamTypeSmall) {
+        video_stream_type_ = liteav::TRTCVideoStreamTypeBig;
         small_pre__bt_stylesheet = "QPushButton{border-image: url(:/switch/image/switch/big_open.png);}";
     }
     ui_video_item_->preSmallVideoBt->setStyleSheet(small_pre__bt_stylesheet);
@@ -170,11 +170,11 @@ void TestUserVideoItem::on_preSmallVideoBt_clicked() {
 
 void TestUserVideoItem::on_mirrorBt_clicked() {
     QString mirror_bt_stylesheet;
-    if (mirror_type_ == trtc::TRTCVideoMirrorType_Enable) {
+    if (mirror_type_ == liteav::TRTCVideoMirrorType_Enable) {
         mirror_bt_stylesheet = "QPushButton{border-image: url(:/switch/image/switch/mirror_close.png);}";
-        mirror_type_ = trtc::TRTCVideoMirrorType_Disable;
-    } else if (mirror_type_ == trtc::TRTCVideoMirrorType_Disable) {
-        mirror_type_ = trtc::TRTCVideoMirrorType_Enable;
+        mirror_type_ = liteav::TRTCVideoMirrorType_Disable;
+    } else if (mirror_type_ == liteav::TRTCVideoMirrorType_Disable) {
+        mirror_type_ = liteav::TRTCVideoMirrorType_Enable;
         mirror_bt_stylesheet = "QPushButton{border-image: url(:/switch/image/switch/mirror_open.png);}";
     }
     ui_video_item_->mirrorBt->setStyleSheet(mirror_bt_stylesheet);
@@ -183,7 +183,7 @@ void TestUserVideoItem::on_mirrorBt_clicked() {
 
 void TestUserVideoItem::on_roateBt_clicked() {
     int roate_index = rotation_;
-    rotation_ = static_cast<trtc::TRTCVideoRotation>((++roate_index) % 4);
+    rotation_ = static_cast<liteav::TRTCVideoRotation>((++roate_index) % 4);
     setRenderParams();
 }
 

--- a/Mac/QTDemo/src/TestBaseScene/test_user_video_item.h
+++ b/Mac/QTDemo/src/TestBaseScene/test_user_video_item.h
@@ -48,7 +48,7 @@ class TestUserVideoItem:public QWidget,public TrtcCloudCallbackDefaultImpl{
 
 public:
     TestUserVideoItem(QWidget *parent = nullptr,
-                      trtc::ITRTCCloud* cloud = nullptr,
+                      liteav::ITRTCCloud* cloud = nullptr,
                       int roomid = 0,
                       std::string userid = nullptr,
                       TEST_VIDEO_ITEM::ViewItemType type = TEST_VIDEO_ITEM::ViewItemType::RemoteView);
@@ -82,7 +82,7 @@ public:
     void changeEvent(QEvent* event);
 private:
     std::unique_ptr<Ui::TestUserVideoItem> ui_video_item_;
-    trtc::ITRTCCloud* trtccloud_;
+    liteav::ITRTCCloud* trtccloud_;
     int room_id_;
     std::string user_id_;
     TEST_VIDEO_ITEM::ViewItemType viewtype_;
@@ -92,10 +92,10 @@ private:
     bool audio_mute_ = false;
     bool video_mute_ = false;
 
-    trtc::TRTCVideoRotation rotation_ = trtc::TRTCVideoRotation0;
-    trtc::TRTCVideoFillMode fill_mode_ = trtc::TRTCVideoFillMode_Fit;
-    trtc::TRTCVideoMirrorType mirror_type_ = trtc::TRTCVideoMirrorType_Disable;
-    trtc::TRTCVideoStreamType video_stream_type_ = trtc::TRTCVideoStreamType::TRTCVideoStreamTypeBig;
+    liteav::TRTCVideoRotation rotation_ = liteav::TRTCVideoRotation0;
+    liteav::TRTCVideoFillMode fill_mode_ = liteav::TRTCVideoFillMode_Fit;
+    liteav::TRTCVideoMirrorType mirror_type_ = liteav::TRTCVideoMirrorType_Disable;
+    liteav::TRTCVideoStreamType video_stream_type_ = liteav::TRTCVideoStreamType::TRTCVideoStreamTypeBig;
 };
 
 #endif // USERVIDEOITEM_H

--- a/Mac/QTDemo/src/TestBeautyAndWatermark/test_beauty_and_watermark.cpp
+++ b/Mac/QTDemo/src/TestBeautyAndWatermark/test_beauty_and_watermark.cpp
@@ -22,9 +22,9 @@ void TestBeautyAndWaterMark::setWatermark()
     QByteArray qtmp_file_bytearray = qtmp_file.toLatin1();
     QFile::copy(":watermark/image/watermark/watermark.png", qtmp_file);
     const char *file_path = qtmp_file_bytearray.data();
-    trtccloud->setWaterMark(trtc::TRTCVideoStreamType::TRTCVideoStreamTypeBig,
+    trtccloud->setWaterMark(liteav::TRTCVideoStreamType::TRTCVideoStreamTypeBig,
                             file_path,
-                            trtc::TRTCWaterMarkSrcType::TRTCWaterMarkSrcTypeFile,
+                            liteav::TRTCWaterMarkSrcType::TRTCWaterMarkSrcTypeFile,
                             0,
                             0,
                             0.3,
@@ -34,9 +34,9 @@ void TestBeautyAndWaterMark::setWatermark()
 
 void TestBeautyAndWaterMark::unsetWatermark()
 {
-    trtccloud->setWaterMark(trtc::TRTCVideoStreamType::TRTCVideoStreamTypeBig,
+    trtccloud->setWaterMark(liteav::TRTCVideoStreamType::TRTCVideoStreamTypeBig,
                             nullptr,
-                            trtc::TRTCWaterMarkSrcType::TRTCWaterMarkSrcTypeFile,
+                            liteav::TRTCWaterMarkSrcType::TRTCWaterMarkSrcTypeFile,
                             0,
                             0,
                             0.1,
@@ -66,9 +66,9 @@ void TestBeautyAndWaterMark::updateBeautyStyle()
 void TestBeautyAndWaterMark::on_comboBoxBeautyStyle_currentIndexChanged(int index)
 {
     if(index == 0) {
-        current_beauty_style_ = trtc::TRTCBeautyStyle::TRTCBeautyStyleSmooth;
+        current_beauty_style_ = liteav::TRTCBeautyStyle::TRTCBeautyStyleSmooth;
     } else if (index == 1) {
-        current_beauty_style_ = trtc::TRTCBeautyStyle::TRTCBeautyStyleNature;
+        current_beauty_style_ = liteav::TRTCBeautyStyle::TRTCBeautyStyleNature;
     }
     updateBeautyStyle();
 }

--- a/Mac/QTDemo/src/TestBeautyAndWatermark/test_beauty_and_watermark.h
+++ b/Mac/QTDemo/src/TestBeautyAndWatermark/test_beauty_and_watermark.h
@@ -62,10 +62,10 @@ private:
 
 private:
     std::unique_ptr<Ui::TestBeautyAndWaterMarkDialog> ui_beauty_and_watermark_;
-    trtc::ITRTCCloud *trtccloud;
+    liteav::ITRTCCloud *trtccloud;
 
     QTemporaryDir qtemp_dir_;
-    trtc::TRTCBeautyStyle current_beauty_style_ = trtc::TRTCBeautyStyle::TRTCBeautyStyleSmooth;
+    liteav::TRTCBeautyStyle current_beauty_style_ = liteav::TRTCBeautyStyle::TRTCBeautyStyleSmooth;
     uint32_t current_beauty_level_ = 5;
     uint32_t current_whiteness_level_ = 5;
     uint32_t current_ruddiness_level_ = 5;

--- a/Mac/QTDemo/src/TestBgmSetting/test_bgm_setting.cpp
+++ b/Mac/QTDemo/src/TestBgmSetting/test_bgm_setting.cpp
@@ -21,7 +21,7 @@ TestBGMSetting::~TestBGMSetting(){
 
 void TestBGMSetting::startPlayBgmMusic(std::string& path,int loopCount,bool publish,bool isShortFile)
 {
-    trtc::AudioMusicParam audio_music_param(bgm_music_id,const_cast<char*>(path.c_str()));
+    liteav::AudioMusicParam audio_music_param(bgm_music_id,const_cast<char*>(path.c_str()));
     audio_music_param.loopCount = loopCount;
     audio_music_param.publish = publish;
     audio_music_param.isShortFile = isShortFile;
@@ -41,7 +41,7 @@ void TestBGMSetting::resumePlayBgmMusic(){
     audio_effect_manager_->resumePlayMusic(bgm_music_id);
 }
 
-void TestBGMSetting::setVoiceReverbType(trtc::TXVoiceReverbType type){
+void TestBGMSetting::setVoiceReverbType(liteav::TXVoiceReverbType type){
     audio_effect_manager_->setVoiceReverbType(type);
 }
 
@@ -158,7 +158,7 @@ void TestBGMSetting::on_btnRestSetting_clicked(){
 }
 
 void TestBGMSetting::on_comboxSetVoiceReverbType_currentIndexChanged(int index){
-    setVoiceReverbType(static_cast<trtc::TXVoiceReverbType>(index));
+    setVoiceReverbType(static_cast<liteav::TXVoiceReverbType>(index));
 }
 
 void TestBGMSetting::on_sliderSetVoiceCaptureVolum_valueChanged(int value){

--- a/Mac/QTDemo/src/TestBgmSetting/test_bgm_setting.h
+++ b/Mac/QTDemo/src/TestBgmSetting/test_bgm_setting.h
@@ -41,7 +41,7 @@
 #include "ui_TestBGMSettingDialog.h"
 #include "base_dialog.h"
 
-class TestBGMSetting:public BaseDialog,public trtc::ITXMusicPlayObserver
+class TestBGMSetting:public BaseDialog,public liteav::ITXMusicPlayObserver
 {
     Q_OBJECT
 public:
@@ -55,7 +55,7 @@ private:
     void pausePlayBgmMusic();
     void resumePlayBgmMusic();
 
-    void setVoiceReverbType(trtc::TXVoiceReverbType type);
+    void setVoiceReverbType(liteav::TXVoiceReverbType type);
     void setMusicPublishVolume(int volume);
     void setMusicPlayoutVolume(int volume);
     void setAllMusicVolume(int volume);
@@ -110,7 +110,7 @@ private:
     void updateDynamicTextUI() override;
 private:
      std::unique_ptr<Ui::TestBGMSettingDialog> ui_bgm_setting_;
-     trtc::ITXAudioEffectManager* audio_effect_manager_ = nullptr;
+     liteav::ITXAudioEffectManager* audio_effect_manager_ = nullptr;
      QTemporaryDir qtemp_dir_;
      int bgm_music_id = -1;
      bool started_bgm_status_ = false;

--- a/Mac/QTDemo/src/TestCDNPlayer/test_cdn_player.cpp
+++ b/Mac/QTDemo/src/TestCDNPlayer/test_cdn_player.cpp
@@ -46,7 +46,7 @@ void TestCdnPlayer::on_btStart_clicked(){
         QString stream_url = QString("http://%1/live/%2.flv").arg(domain).arg(stream_id);
 
         std::string play_url = stream_url.toStdString();
-        live_player_->setRenderFrame(reinterpret_cast<trtc::TXView>(ui_test_cdn_player_->videoPlaceHolder->winId()));
+        live_player_->setRenderFrame(reinterpret_cast<liteav::TXView>(ui_test_cdn_player_->videoPlaceHolder->winId()));
         live_player_->startPlay(play_url.c_str());
     }
     paused_ = false;

--- a/Mac/QTDemo/src/TestCDNPublish/test_cdn_publish.cpp
+++ b/Mac/QTDemo/src/TestCDNPublish/test_cdn_publish.cpp
@@ -31,7 +31,7 @@ void TestCdnPublish::stopPublishing(){
 
 void TestCdnPublish::startPublishing(std::string streamId){
     if(!is_publishing_) {
-        getTRTCShareInstance()->startPublishing(streamId.c_str(),trtc::TRTCVideoStreamTypeBig);
+        getTRTCShareInstance()->startPublishing(streamId.c_str(),liteav::TRTCVideoStreamTypeBig);
     }
 }
 

--- a/Mac/QTDemo/src/TestCustomCapture/test_custom_capture.cpp
+++ b/Mac/QTDemo/src/TestCustomCapture/test_custom_capture.cpp
@@ -39,8 +39,8 @@ void TestCustomCapture::startCustomAudioData(QString path) {
             }
             QByteArray array;
             array = file.read(buffer_size);
-            trtc::TRTCAudioFrame frame;
-            frame.audioFormat = trtc::TRTCAudioFrameFormatPCM;
+            liteav::TRTCAudioFrame frame;
+            frame.audioFormat = liteav::TRTCAudioFrameFormatPCM;
             frame.length = buffer_size;
             frame.data = array.data();
             frame.sampleRate = 48000;
@@ -77,14 +77,14 @@ void TestCustomCapture::startCustomVideoData(QString path) {
 
             QByteArray array;
             array = file.read(buffer_size);
-            trtc::TRTCVideoFrame frame;
+            liteav::TRTCVideoFrame frame;
 
             if (ui_test_custom_capture_->cbEnableCustomTimeCapture) {
                 frame.timestamp = getTRTCShareInstance()->generateCustomPTS();
             }
 
-            frame.videoFormat = trtc::TRTCVideoPixelFormat_I420;
-            frame.bufferType = trtc::TRTCVideoBufferType_Buffer;
+            frame.videoFormat = liteav::TRTCVideoPixelFormat_I420;
+            frame.bufferType = liteav::TRTCVideoBufferType_Buffer;
             frame.length = buffer_size;
             frame.data = array.data();
             frame.width = 320;
@@ -102,7 +102,7 @@ void TestCustomCapture::startCustomVideoData(QString path) {
 
 void TestCustomCapture::stopCustomAudioData() {
     getTRTCShareInstance()->enableCustomAudioCapture(false);
-    getTRTCShareInstance()->startLocalAudio(trtc::TRTCAudioQualityDefault);
+    getTRTCShareInstance()->startLocalAudio(liteav::TRTCAudioQualityDefault);
 }
 
 void TestCustomCapture::stopCustomVideoData() {

--- a/Mac/QTDemo/src/TestCustomMessage/TestCustomMessageDialog.ui
+++ b/Mac/QTDemo/src/TestCustomMessage/TestCustomMessageDialog.ui
@@ -294,7 +294,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextBrowser" name="textBrowserMsgDetail">
+    <widget class="QTextEdit" name="textEditMsgDetail">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -305,22 +305,6 @@
       <font>
        <pointsize>14</pointsize>
       </font>
-     </property>
-     <property name="documentTitle">
-      <string notr="true"/>
-     </property>
-     <property name="markdown">
-      <string notr="true"/>
-     </property>
-     <property name="html">
-      <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'SimSun'; font-size:14pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="searchPaths">
-      <stringlist notr="true"/>
      </property>
     </widget>
    </item>

--- a/Mac/QTDemo/src/TestCustomMessage/test_custom_message.cpp
+++ b/Mac/QTDemo/src/TestCustomMessage/test_custom_message.cpp
@@ -30,7 +30,7 @@ void TestCustomMessage::onRecvSEIMsg(const char *userId, const uint8_t *message,
     text = "userId: " + QString(userId) +
             ", message: " + QString(reinterpret_cast<const char *>(message)) +
             ", messageSize: " + QString(QString::number(messageSize));
-    ui_custom_message_->textBrowserMsgDetail->setText(text);
+    ui_custom_message_->textEditMsgDetail->setText(text);
 }
 
 void TestCustomMessage::onMissCustomCmdMsg(const char *userId, int32_t cmdID, int32_t errCode, int32_t missed)
@@ -40,7 +40,7 @@ void TestCustomMessage::onMissCustomCmdMsg(const char *userId, int32_t cmdID, in
             ", cmdID: " + QString(QString::number(cmdID)) +
             ", errCode: " + QString(QString::number(errCode)) +
             ", missed: " + QString(QString::number(missed));
-    ui_custom_message_->textBrowserMsgDetail->setText(text);
+    ui_custom_message_->textEditMsgDetail->setText(text);
 }
 
 void TestCustomMessage::onRecvCustomCmdMsg(const char *userId, int32_t cmdID, uint32_t seq, const uint8_t *message, uint32_t messageSize)
@@ -51,7 +51,7 @@ void TestCustomMessage::onRecvCustomCmdMsg(const char *userId, int32_t cmdID, ui
             ", seq: " + QString(QString::number(seq)) +
             ", message: " + QString(reinterpret_cast<const char *>(message)) +
             ", messageSize: " + QString(QString::number(messageSize));
-    ui_custom_message_->textBrowserMsgDetail->setText(text);
+    ui_custom_message_->textEditMsgDetail->setText(text);
 }
 //============= ITRTCCloudCallback end ===================//
 
@@ -117,7 +117,7 @@ void TestCustomMessage::on_pushButtonSendSEIMsg_clicked()
 
 void TestCustomMessage::closeEvent(QCloseEvent *event)
 {
-    ui_custom_message_->textBrowserMsgDetail->setText("");
+    ui_custom_message_->textEditMsgDetail->setText("");
     BaseDialog::closeEvent(event);
 }
 

--- a/Mac/QTDemo/src/TestCustomMessage/test_custom_message.h
+++ b/Mac/QTDemo/src/TestCustomMessage/test_custom_message.h
@@ -61,7 +61,7 @@ public:
 
 private:
     std::unique_ptr<Ui::TestCustomMessageDialog> ui_custom_message_;
-    trtc::ITRTCCloud *trtccloud_;
+    liteav::ITRTCCloud *trtccloud_;
 };
 
 #endif // TESTCUSTOMMESSAGE_H

--- a/Mac/QTDemo/src/TestCustomRender/test_custom_render.cpp
+++ b/Mac/QTDemo/src/TestCustomRender/test_custom_render.cpp
@@ -16,40 +16,40 @@ TestCustomRender::~TestCustomRender() {
 void TestCustomRender::startLocalVideoRender(){
     getTRTCShareInstance()->startLocalPreview(nullptr);
     getTRTCShareInstance()->setLocalVideoRenderCallback(
-                trtc::TRTCVideoPixelFormat_I420
-                ,trtc::TRTCVideoBufferType_Buffer
+                liteav::TRTCVideoPixelFormat_I420
+                ,liteav::TRTCVideoBufferType_Buffer
                 ,this);
 }
 void TestCustomRender::startRemoteVideoRender(std::string& userId){
     getTRTCShareInstance()->setRemoteVideoRenderCallback(
                 userId.c_str()
-                ,trtc::TRTCVideoPixelFormat_I420
-                ,trtc::TRTCVideoBufferType_Buffer
+                ,liteav::TRTCVideoPixelFormat_I420
+                ,liteav::TRTCVideoBufferType_Buffer
                 ,this);
 }
 
 void TestCustomRender::stopLocalVideoRender(){
     getTRTCShareInstance()->setLocalVideoRenderCallback(
-                trtc::TRTCVideoPixelFormat_Unknown
-                ,trtc::TRTCVideoBufferType_Unknown
+                liteav::TRTCVideoPixelFormat_Unknown
+                ,liteav::TRTCVideoBufferType_Unknown
                 ,nullptr);
 
 }
 void TestCustomRender::stopRemoteVideoRender(std::string& userId){
     getTRTCShareInstance()->setRemoteVideoRenderCallback(
                 userId.c_str()
-                ,trtc::TRTCVideoPixelFormat_Unknown
-                ,trtc::TRTCVideoBufferType_Unknown
+                ,liteav::TRTCVideoPixelFormat_Unknown
+                ,liteav::TRTCVideoBufferType_Unknown
                 ,nullptr);
 }
 
 //============= ITRTCVideoRenderCallback start ===================//
-void TestCustomRender::onRenderVideoFrame(const char *userId, trtc::TRTCVideoStreamType streamType, trtc::TRTCVideoFrame *frame){
+void TestCustomRender::onRenderVideoFrame(const char *userId, liteav::TRTCVideoStreamType streamType, liteav::TRTCVideoFrame *frame){
     if(gl_yuv_widget_ == nullptr){
         return;
     }
 
-    if(streamType == trtc::TRTCVideoStreamType::TRTCVideoStreamTypeBig){
+    if(streamType == liteav::TRTCVideoStreamType::TRTCVideoStreamTypeBig){
         emit renderViewSize(frame->width,frame->height);
         gl_yuv_widget_->slotShowYuv(reinterpret_cast<uchar*>(frame->data),frame->width,frame->height);
     }

--- a/Mac/QTDemo/src/TestCustomRender/test_custom_render.h
+++ b/Mac/QTDemo/src/TestCustomRender/test_custom_render.h
@@ -30,7 +30,7 @@
 #include "gl_yuv_widget.h"
 #include "ui_TestCustomRenderDialog.h"
 
-class TestCustomRender:public BaseDialog, public trtc::ITRTCVideoRenderCallback
+class TestCustomRender:public BaseDialog, public liteav::ITRTCVideoRenderCallback
 {
     Q_OBJECT
 public:
@@ -45,7 +45,7 @@ private:
     void stopRemoteVideoRender(std::string& userId);
 
     //============= ITRTCVideoRenderCallback start ===================//
-    void onRenderVideoFrame(const char *userId, trtc::TRTCVideoStreamType streamType, trtc::TRTCVideoFrame *frame) override;
+    void onRenderVideoFrame(const char *userId, liteav::TRTCVideoStreamType streamType, liteav::TRTCVideoFrame *frame) override;
     //=============  ITRTCVideoRenderCallback end  ===================//
 
 private slots:

--- a/Mac/QTDemo/src/TestDeviceManager/test_device_manager.cpp
+++ b/Mac/QTDemo/src/TestDeviceManager/test_device_manager.cpp
@@ -37,14 +37,14 @@ void TestDeviceManager::refreshMicDevices()
     if(tx_device_manager_ == nullptr) {
         return;
     }
-    trtc::ITXDeviceCollection* device_collection_microphone = tx_device_manager_->getDevicesList(trtc::TXMediaDeviceType::TXMediaDeviceTypeMic);
+    liteav::ITXDeviceCollection* device_collection_microphone = tx_device_manager_->getDevicesList(liteav::TXMediaDeviceType::TXMediaDeviceTypeMic);
     uint32_t microphone_device_count = device_collection_microphone->getCount();
     if(microphone_device_count != 0) {
-        trtc::ITXDeviceInfo *current_microphone_device = tx_device_manager_->getCurrentDevice(trtc::TXMediaDeviceType::TXMediaDeviceTypeMic);
+        liteav::ITXDeviceInfo *current_microphone_device = tx_device_manager_->getCurrentDevice(liteav::TXMediaDeviceType::TXMediaDeviceTypeMic);
         ui_device_manager_->microphoneChooseComboBox->clear();
         uint32_t current_selected_microphone_device_index = 0;
         for(uint32_t index = 0; index < microphone_device_count; index++) {
-            const DeviceInfoItem item = DeviceInfoItem(device_collection_microphone->getDeviceName(index), device_collection_microphone->getDevicePID(index), trtc::TXMediaDeviceType::TXMediaDeviceTypeMic);
+            const DeviceInfoItem item = DeviceInfoItem(device_collection_microphone->getDeviceName(index), device_collection_microphone->getDevicePID(index), liteav::TXMediaDeviceType::TXMediaDeviceTypeMic);
             qvector_device_info_microphone_.append(item);
             ui_device_manager_->microphoneChooseComboBox->addItem(QString::fromStdString(item.device_name_));
             if(strcmp(item.device_id_.data(), current_microphone_device->getDevicePID()) == 0) {
@@ -63,14 +63,14 @@ void TestDeviceManager::refreshCameraDevices()
     if(tx_device_manager_ == nullptr) {
         return;
     }
-    trtc::ITXDeviceCollection* device_collection_camera = tx_device_manager_->getDevicesList(trtc::TXMediaDeviceType::TXMediaDeviceTypeCamera);
+    liteav::ITXDeviceCollection* device_collection_camera = tx_device_manager_->getDevicesList(liteav::TXMediaDeviceType::TXMediaDeviceTypeCamera);
     uint32_t camera_device_count = device_collection_camera->getCount();
     if(camera_device_count != 0) {
-        trtc::ITXDeviceInfo *current_camera_device = tx_device_manager_->getCurrentDevice(trtc::TXMediaDeviceType::TXMediaDeviceTypeCamera);
+        liteav::ITXDeviceInfo *current_camera_device = tx_device_manager_->getCurrentDevice(liteav::TXMediaDeviceType::TXMediaDeviceTypeCamera);
         ui_device_manager_->cameraChooseComboBox->clear();
         uint32_t current_selected_camera_device_index = 0;
         for(uint32_t index = 0; index < camera_device_count; index++) {
-            const DeviceInfoItem item = DeviceInfoItem(device_collection_camera->getDeviceName(index), device_collection_camera->getDevicePID(index), trtc::TXMediaDeviceType::TXMediaDeviceTypeCamera);
+            const DeviceInfoItem item = DeviceInfoItem(device_collection_camera->getDeviceName(index), device_collection_camera->getDevicePID(index), liteav::TXMediaDeviceType::TXMediaDeviceTypeCamera);
             qvector_device_info_camera_.append(item);
             ui_device_manager_->cameraChooseComboBox->addItem(QString::fromStdString(item.device_name_));
             if(strcmp(item.device_id_.data(), current_camera_device->getDevicePID()) == 0) {
@@ -89,14 +89,14 @@ void TestDeviceManager::refreshSpeakerDevices()
     if(tx_device_manager_ == nullptr) {
         return;
     }
-    trtc::ITXDeviceCollection* device_collection_loudspeaker = tx_device_manager_->getDevicesList(trtc::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
+    liteav::ITXDeviceCollection* device_collection_loudspeaker = tx_device_manager_->getDevicesList(liteav::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
     uint32_t loudspeaker_device_count = device_collection_loudspeaker->getCount();
     if(loudspeaker_device_count != 0) {
-        trtc::ITXDeviceInfo *current_loudspeaker_device = tx_device_manager_->getCurrentDevice(trtc::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
+        liteav::ITXDeviceInfo *current_loudspeaker_device = tx_device_manager_->getCurrentDevice(liteav::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
         ui_device_manager_->loudspeakerChooseComboBox->clear();
         uint32_t current_selected_loudspeaker_device_index = 0;
         for(uint32_t index = 0; index < loudspeaker_device_count; index++) {
-            const DeviceInfoItem item = DeviceInfoItem(device_collection_loudspeaker->getDeviceName(index), device_collection_loudspeaker->getDevicePID(index), trtc::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
+            const DeviceInfoItem item = DeviceInfoItem(device_collection_loudspeaker->getDeviceName(index), device_collection_loudspeaker->getDevicePID(index), liteav::TXMediaDeviceType::TXMediaDeviceTypeSpeaker);
             qvector_device_info_loudspeaker_.append(item);
             ui_device_manager_->loudspeakerChooseComboBox->addItem(QString::fromStdString(item.device_name_));
             if(strcmp(item.device_id_.data(), current_loudspeaker_device->getDevicePID()) == 0) {

--- a/Mac/QTDemo/src/TestDeviceManager/test_device_manager.h
+++ b/Mac/QTDemo/src/TestDeviceManager/test_device_manager.h
@@ -43,7 +43,7 @@ public:
     ~TestDeviceManager();
 
     //============= ITRTCCloudCallback start =================//
-    // void onDeviceChange(const char* deviceId, trtc::TRTCDeviceType type, trtc::TRTCDeviceState state) override;
+    // void onDeviceChange(const char* deviceId, liteav::TRTCDeviceType type, liteav::TRTCDeviceState state) override;
     //============= ITRTCCloudCallback end ===================//
 
 private:
@@ -56,10 +56,10 @@ private:
 
     std::string device_name_;
     std::string device_id_;
-    trtc::TXMediaDeviceType device_type_;
+    liteav::TXMediaDeviceType device_type_;
 
     DeviceInfoItem(){}
-    DeviceInfoItem(std::string device_name, std::string device_id, trtc::TXMediaDeviceType device_type) :
+    DeviceInfoItem(std::string device_name, std::string device_id, liteav::TXMediaDeviceType device_type) :
             device_name_(device_name), device_id_(device_id), device_type_(device_type) {}
 
     };
@@ -74,7 +74,7 @@ private:
 
     bool device_info_ready_;
     std::unique_ptr<Ui::TestDeviceMangerDialog> ui_device_manager_;
-    trtc::ITXDeviceManager *tx_device_manager_;
+    liteav::ITXDeviceManager *tx_device_manager_;
     QVector<DeviceInfoItem> qvector_device_info_camera_;
     QVector<DeviceInfoItem> qvector_device_info_microphone_;
     QVector<DeviceInfoItem> qvector_device_info_loudspeaker_;

--- a/Mac/QTDemo/src/TestLogSetting/test_log_setting.cpp
+++ b/Mac/QTDemo/src/TestLogSetting/test_log_setting.cpp
@@ -20,7 +20,7 @@ TestLogSetting::~TestLogSetting(){
 }
 
 void TestLogSetting::setLogLevel(){
-    trtc::TRTCLogLevel log_level = static_cast<trtc::TRTCLogLevel>(ui_test_log_setting_->setLogLevelCb->currentIndex());
+    liteav::TRTCLogLevel log_level = static_cast<liteav::TRTCLogLevel>(ui_test_log_setting_->setLogLevelCb->currentIndex());
     getTRTCShareInstance()->setLogLevel(log_level);
 }
 
@@ -51,7 +51,7 @@ void TestLogSetting::setLogDirPath(){
 
 
 //============= ITRTCLogCallback start =================//
-void TestLogSetting::onLog(const char *log, trtc::TRTCLogLevel level, const char *module){
+void TestLogSetting::onLog(const char *log, liteav::TRTCLogLevel level, const char *module){
 
     QByteArray localMsg = QString::fromUtf8(log).toLocal8Bit();
     QString current_date_time = QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss");

--- a/Mac/QTDemo/src/TestLogSetting/test_log_setting.h
+++ b/Mac/QTDemo/src/TestLogSetting/test_log_setting.h
@@ -25,7 +25,7 @@
 #include "TRTCCloudCallback.h"
 #include "ui_TestLogSettingDialog.h"
 
-class TestLogSetting:public BaseDialog,public trtc::ITRTCLogCallback
+class TestLogSetting:public BaseDialog,public liteav::ITRTCLogCallback
 {
     Q_OBJECT
 public:
@@ -38,7 +38,7 @@ private:
     void setLogCompressEnabled();
     void setLogDirPath();
     //============= ITRTCLogCallback start =================//
-    void onLog(const char *log, trtc::TRTCLogLevel level, const char *module) override;
+    void onLog(const char *log, liteav::TRTCLogLevel level, const char *module) override;
     //============= ITRTCLogCallback end ===================//
 
 private slots:

--- a/Mac/QTDemo/src/TestMixStreamPublish/test_mix_stream_publish.cpp
+++ b/Mac/QTDemo/src/TestMixStreamPublish/test_mix_stream_publish.cpp
@@ -95,7 +95,7 @@ void TestMixStreamPublish::startPresetLayoutTemplate(){
     RoomInfoHolder::GetInstance().setMixTranscodingStreamId(streamid_str);
 
     std::string roomid_str = std::to_string(RoomInfoHolder::GetInstance().getMainRoomId());
-    trtc::TRTCMixUser* mix_users_array = NULL;
+    liteav::TRTCMixUser* mix_users_array = NULL;
 
     // The number of users whose streams are mixed. 4 is used in the demo.
     int current_mix_size = 4;
@@ -103,7 +103,7 @@ void TestMixStreamPublish::startPresetLayoutTemplate(){
     int remote_item_height = video_height_ / 4;
     int remote_item_width = remote_item_height;
 
-    mix_users_array = new trtc::TRTCMixUser[current_mix_size];
+    mix_users_array = new liteav::TRTCMixUser[current_mix_size];
 
     mix_users_array[0].userId = "$PLACE_HOLDER_LOCAL_MAIN$";
 
@@ -121,8 +121,8 @@ void TestMixStreamPublish::startPresetLayoutTemplate(){
         // The value is a placeholder, not the actual user ID.
         mix_users_array[current_pos].userId = "$PLACE_HOLDER_REMOTE$";
         mix_users_array[current_pos].roomId = roomid_str.c_str();
-        mix_users_array[current_pos].streamType = trtc::TRTCVideoStreamTypeBig;
-        mix_users_array[current_pos].inputType = trtc::TRTCMixInputTypeAudioVideo;
+        mix_users_array[current_pos].streamType = liteav::TRTCVideoStreamTypeBig;
+        mix_users_array[current_pos].inputType = liteav::TRTCMixInputTypeAudioVideo;
         mix_users_array[current_pos].zOrder = 1;
 
         // Start from 0 (left to right)
@@ -160,7 +160,7 @@ void TestMixStreamPublish::startManualTemplate(){
     RoomInfoHolder::GetInstance().setMixTranscodingStreamId(streamid_str);
 
     std::string roomid_str = std::to_string(RoomInfoHolder::GetInstance().getMainRoomId());
-    trtc::TRTCMixUser* mix_users_array = NULL;
+    liteav::TRTCMixUser* mix_users_array = NULL;
 
     // The number of users whose streams are mixed.
     int current_mix_size;
@@ -174,7 +174,7 @@ void TestMixStreamPublish::startManualTemplate(){
 
     current_mix_size = mix_usersarray_size > max_mix_size ? max_mix_size : mix_usersarray_size;
 
-    mix_users_array = new trtc::TRTCMixUser[current_mix_size];
+    mix_users_array = new liteav::TRTCMixUser[current_mix_size];
 
     mix_users_array[0].userId = local_user_id.c_str();
 
@@ -186,9 +186,9 @@ void TestMixStreamPublish::startManualTemplate(){
     mix_users_array[0].roomId = roomid_str.c_str();
 
     if (screen_shared_started_) {
-        mix_users_array[0].streamType = trtc::TRTCVideoStreamTypeSub;
+        mix_users_array[0].streamType = liteav::TRTCVideoStreamTypeSub;
     } else {
-        mix_users_array[0].streamType = trtc::TRTCVideoStreamTypeBig;
+        mix_users_array[0].streamType = liteav::TRTCVideoStreamTypeBig;
     }
 
     int current_pos = 1;
@@ -199,21 +199,21 @@ void TestMixStreamPublish::startManualTemplate(){
 
         mix_users_array[current_pos].userId = remote_info->user_id_.c_str();
         mix_users_array[current_pos].roomId = roomid_str.c_str();
-        mix_users_array[current_pos].streamType = trtc::TRTCVideoStreamTypeBig;
+        mix_users_array[current_pos].streamType = liteav::TRTCVideoStreamTypeBig;
 
         if (remote_info->video_available_) {
-            mix_users_array[current_pos].inputType = trtc::TRTCMixInputTypePureVideo;
+            mix_users_array[current_pos].inputType = liteav::TRTCMixInputTypePureVideo;
         }
 
         if (remote_info->audio_available_) {
-            mix_users_array[current_pos].inputType = trtc::TRTCMixInputTypePureAudio;
+            mix_users_array[current_pos].inputType = liteav::TRTCMixInputTypePureAudio;
         }
 
         if (remote_info->video_available_ && remote_info->audio_available_) {
-            mix_users_array[current_pos].inputType = trtc::TRTCMixInputTypeAudioVideo;
+            mix_users_array[current_pos].inputType = liteav::TRTCMixInputTypeAudioVideo;
         }
 
-        mix_users_array[current_pos].inputType = trtc::TRTCMixInputTypeAudioVideo;
+        mix_users_array[current_pos].inputType = liteav::TRTCMixInputTypeAudioVideo;
         mix_users_array[current_pos].zOrder = 1;
 
         // Start from 0 (left to right)
@@ -298,7 +298,7 @@ void TestMixStreamPublish::onUserVideoAvailable(const char * userId, bool availa
         }
     }
 
-    if (mix_config_mode_ == trtc::TRTCTranscodingConfigMode_Manual && started_transcoding_){
+    if (mix_config_mode_ == liteav::TRTCTranscodingConfigMode_Manual && started_transcoding_){
         updateTranscodingConfig();
     }
 }
@@ -327,21 +327,21 @@ void TestMixStreamPublish::onUserAudioAvailable(const char * userId, bool availa
         }
     }
 
-    if (mix_config_mode_ == trtc::TRTCTranscodingConfigMode_Manual && started_transcoding_) {
+    if (mix_config_mode_ == liteav::TRTCTranscodingConfigMode_Manual && started_transcoding_) {
         updateTranscodingConfig();
     }
 }
 
 void TestMixStreamPublish::onScreenCaptureStarted(){
     screen_shared_started_ = true;
-    if (mix_config_mode_ == trtc::TRTCTranscodingConfigMode_Manual && started_transcoding_) {
+    if (mix_config_mode_ == liteav::TRTCTranscodingConfigMode_Manual && started_transcoding_) {
         updateTranscodingConfig();
     }
 }
 
 void TestMixStreamPublish::onScreenCaptureStoped(int reason){
     screen_shared_started_ = false;
-    if (mix_config_mode_ == trtc::TRTCTranscodingConfigMode_Manual && started_transcoding_) {
+    if (mix_config_mode_ == liteav::TRTCTranscodingConfigMode_Manual && started_transcoding_) {
         updateTranscodingConfig();
     }
 }
@@ -362,7 +362,7 @@ void TestMixStreamPublish::initUI(){
     connect(ui_test_mix_stream_publish_->radioButtonPresetLayout, SIGNAL(clicked(bool)), this, SLOT(on_config_mode_checked_change()));
     connect(ui_test_mix_stream_publish_->radioButtonScreenSharing, SIGNAL(clicked(bool)), this, SLOT(on_config_mode_checked_change()));
     connect(ui_test_mix_stream_publish_->radioButtonPureAudio, SIGNAL(clicked(bool)), this, SLOT(on_config_mode_checked_change()));
-    mix_config_mode_ = trtc::TRTCTranscodingConfigMode_Manual;
+    mix_config_mode_ = liteav::TRTCTranscodingConfigMode_Manual;
     ui_test_mix_stream_publish_->startMixStreamPublishBt->setEnabled(isStartMixStreamBtAvailable());
 }
 
@@ -372,19 +372,19 @@ void TestMixStreamPublish::on_streamIdLineEt_textChanged(const QString &streamId
 
 void TestMixStreamPublish::updateTranscodingConfig()
 {
-    if (mix_config_mode_ == trtc::TRTCTranscodingConfigMode_Template_PureAudio) {
+    if (mix_config_mode_ == liteav::TRTCTranscodingConfigMode_Template_PureAudio) {
         startPureAudioTemplate();
     }
 
-    if (mix_config_mode_ == trtc::TRTCTranscodingConfigMode_Template_ScreenSharing) {
+    if (mix_config_mode_ == liteav::TRTCTranscodingConfigMode_Template_ScreenSharing) {
         startScreenSharingTemplate();
     }
 
-    if (mix_config_mode_ == trtc::TRTCTranscodingConfigMode_Template_PresetLayout) {
+    if (mix_config_mode_ == liteav::TRTCTranscodingConfigMode_Template_PresetLayout) {
         startPresetLayoutTemplate();
     }
 
-    if (mix_config_mode_ == trtc::TRTCTranscodingConfigMode_Manual) {
+    if (mix_config_mode_ == liteav::TRTCTranscodingConfigMode_Manual) {
         startManualTemplate();
     }
 }
@@ -393,19 +393,19 @@ void TestMixStreamPublish::on_config_mode_checked_change()
 {
     switch(config_mode_button_group.checkedId()) {
     case 0: {
-        mix_config_mode_ = trtc::TRTCTranscodingConfigMode_Manual;
+        mix_config_mode_ = liteav::TRTCTranscodingConfigMode_Manual;
         break;
     }
     case 1: {
-        mix_config_mode_ = trtc::TRTCTranscodingConfigMode_Template_PresetLayout;
+        mix_config_mode_ = liteav::TRTCTranscodingConfigMode_Template_PresetLayout;
         break;
     }
     case 2: {
-        mix_config_mode_ = trtc::TRTCTranscodingConfigMode_Template_ScreenSharing;
+        mix_config_mode_ = liteav::TRTCTranscodingConfigMode_Template_ScreenSharing;
         break;
     }
     case 3: {
-        mix_config_mode_ = trtc::TRTCTranscodingConfigMode_Template_PureAudio;
+        mix_config_mode_ = liteav::TRTCTranscodingConfigMode_Template_PureAudio;
         break;
     }
     default: {
@@ -427,7 +427,7 @@ bool TestMixStreamPublish::getTranscodingConfig(){
     audio_bitrate_ = ui_test_mix_stream_publish_->audioBitrateEt->text().toInt();
     audio_channels_ = (ui_test_mix_stream_publish_->audioChannelsComB->currentIndex() == 0)?1:2;
 
-    if (mix_config_mode_ == trtc::TRTCTranscodingConfigMode_Unknown) {
+    if (mix_config_mode_ == liteav::TRTCTranscodingConfigMode_Unknown) {
         QMessageBox::warning(this, "Failed to publish mixed streams", "Select a layout mode.", QMessageBox::Ok);
         return false;
     }

--- a/Mac/QTDemo/src/TestMixStreamPublish/test_mix_stream_publish.h
+++ b/Mac/QTDemo/src/TestMixStreamPublish/test_mix_stream_publish.h
@@ -102,9 +102,9 @@ private:
 private:
     std::unique_ptr<Ui::TestMixStreamPublishDialog> ui_test_mix_stream_publish_;
 
-    trtc::TRTCTranscodingConfig trtc_transcoding_config;
+    liteav::TRTCTranscodingConfig trtc_transcoding_config;
     //============= TRTCTranscodingConfig start ===============//
-    trtc::TRTCTranscodingConfigMode mix_config_mode_ = trtc::TRTCTranscodingConfigMode_Unknown;
+    liteav::TRTCTranscodingConfigMode mix_config_mode_ = liteav::TRTCTranscodingConfigMode_Unknown;
     uint32_t    video_width_      = 360;
     uint32_t    video_height_     = 640;
     uint32_t    video_bitrate_    = 64;

--- a/Mac/QTDemo/src/TestNetworkCheck/TestNetworkCheckDialog.ui
+++ b/Mac/QTDemo/src/TestNetworkCheck/TestNetworkCheckDialog.ui
@@ -79,24 +79,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextBrowser" name="resultQtb">
-     <property name="documentTitle">
-      <string notr="true"/>
-     </property>
-     <property name="markdown">
-      <string notr="true"/>
-     </property>
-     <property name="html">
-      <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'SimSun'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="searchPaths">
-      <stringlist notr="true"/>
-     </property>
-    </widget>
+    <widget class="QTextEdit" name="resultQtb"/>
    </item>
   </layout>
  </widget>

--- a/Mac/QTDemo/src/TestNetworkCheck/test_network_check.cpp
+++ b/Mac/QTDemo/src/TestNetworkCheck/test_network_check.cpp
@@ -49,7 +49,7 @@ void TestNetworkCheck::stopSpeedTest(){
 
 //============= ITRTCCloudCallback start===================//
 
-void TestNetworkCheck::onSpeedTest(const trtc::TRTCSpeedTestResult &currentResult, uint32_t finishedCount, uint32_t totalCount){
+void TestNetworkCheck::onSpeedTest(const liteav::TRTCSpeedTestResult &currentResult, uint32_t finishedCount, uint32_t totalCount){
     QString result = QString("Progress: " + QString::number(finishedCount) + "/" + QString::number(totalCount)+"\n");
     result.append("ip:").append(QString::fromStdString(currentResult.ip))
             .append(" quality:").append(currentResult.quality)

--- a/Mac/QTDemo/src/TestNetworkCheck/test_network_check.h
+++ b/Mac/QTDemo/src/TestNetworkCheck/test_network_check.h
@@ -41,7 +41,7 @@ private:
 
 private :
     //============= ITRTCCloudCallback start =================//
-    void onSpeedTest(const trtc::TRTCSpeedTestResult &currentResult, uint32_t finishedCount, uint32_t totalCount);
+    void onSpeedTest(const liteav::TRTCSpeedTestResult &currentResult, uint32_t finishedCount, uint32_t totalCount);
     //============= ITRTCCloudCallback end ===================//
 
 private slots:

--- a/Mac/QTDemo/src/TestScreenShare/screen_share_selection_item.cpp
+++ b/Mac/QTDemo/src/TestScreenShare/screen_share_selection_item.cpp
@@ -1,6 +1,6 @@
 #include "screen_share_selection_item.h"
 
-ScreenShareSelectionItem::ScreenShareSelectionItem(trtc::TRTCScreenCaptureSourceInfo& screenCaptureSourceInfo
+ScreenShareSelectionItem::ScreenShareSelectionItem(liteav::TRTCScreenCaptureSourceInfo& screenCaptureSourceInfo
     ,QWidget * parent)
     :QWidget(parent)
     ,ui_screen_share_selection_item_(new Ui::ScreenShareSelectionItem)
@@ -44,9 +44,9 @@ void ScreenShareSelectionItem::mouseReleaseEvent(QMouseEvent *ev){
     ui_screen_share_selection_item_->radioButtonSelected->setChecked(!is_selected);
 }
 
-trtc::TRTCScreenCaptureSourceInfo ScreenShareSelectionItem::getScreenCaptureSourceinfo() const
+liteav::TRTCScreenCaptureSourceInfo ScreenShareSelectionItem::getScreenCaptureSourceinfo() const
 {
-    return static_cast<trtc::TRTCScreenCaptureSourceInfo>(screen_capture_sourceinfo_);
+    return static_cast<liteav::TRTCScreenCaptureSourceInfo>(screen_capture_sourceinfo_);
 }
 
 void ScreenShareSelectionItem::on_radioButtonSelected_clicked(bool checked){

--- a/Mac/QTDemo/src/TestScreenShare/screen_share_selection_item.h
+++ b/Mac/QTDemo/src/TestScreenShare/screen_share_selection_item.h
@@ -20,9 +20,9 @@ class ScreenShareSelectionItem:public QWidget
 {
     Q_OBJECT
 public:
-    explicit ScreenShareSelectionItem(trtc::TRTCScreenCaptureSourceInfo& screenCaptureSourceInfo, QWidget* parent = nullptr);
+    explicit ScreenShareSelectionItem(liteav::TRTCScreenCaptureSourceInfo& screenCaptureSourceInfo, QWidget* parent = nullptr);
     ~ScreenShareSelectionItem();
-    trtc::TRTCScreenCaptureSourceInfo getScreenCaptureSourceinfo() const;
+    liteav::TRTCScreenCaptureSourceInfo getScreenCaptureSourceinfo() const;
     bool isSelected() const;
     void setSelected(bool selected);
 
@@ -40,7 +40,7 @@ private:
 
 private:
     std::unique_ptr<Ui::ScreenShareSelectionItem> ui_screen_share_selection_item_;
-    trtc::TRTCScreenCaptureSourceInfo screen_capture_sourceinfo_;
+    liteav::TRTCScreenCaptureSourceInfo screen_capture_sourceinfo_;
 };
 
 #endif // SCREENSHARESELECTIONITEM_H

--- a/Mac/QTDemo/src/TestScreenShare/test_screen_share_select_screen.cpp
+++ b/Mac/QTDemo/src/TestScreenShare/test_screen_share_select_screen.cpp
@@ -26,7 +26,7 @@ void TestScreenShareSelectScreen::stopScreenSharing(){
 }
 
 void TestScreenShareSelectScreen::startScreenSharing(){
-    getTRTCShareInstance()->startScreenCapture(reinterpret_cast<trtc::TXView>(ui_test_screen_share_select_screen_->screenSharedPreview->winId()),
+    getTRTCShareInstance()->startScreenCapture(reinterpret_cast<liteav::TXView>(ui_test_screen_share_select_screen_->screenSharedPreview->winId()),
         stream_type_,
         &enc_param_);
 }
@@ -46,7 +46,7 @@ void TestScreenShareSelectScreen::releaseScreenCaptureSourceList(){
     }
 }
 
-void TestScreenShareSelectScreen::selectScreenCaptureTarget(trtc::TRTCScreenCaptureSourceInfo sourceInfo){
+void TestScreenShareSelectScreen::selectScreenCaptureTarget(liteav::TRTCScreenCaptureSourceInfo sourceInfo){
     getTRTCShareInstance()->selectScreenCaptureTarget(
         sourceInfo
         , sharing_rect_
@@ -66,10 +66,10 @@ void TestScreenShareSelectScreen::initScreenCaptureSources(){
     screen_capture_list_ = getTRTCShareInstance()->getScreenCaptureSources(thumb_size, icon_size);
 }
 
-void TestScreenShareSelectScreen::init(trtc::TRTCScreenCaptureProperty captureProperty
-    , trtc::TRTCVideoEncParam params
+void TestScreenShareSelectScreen::init(liteav::TRTCScreenCaptureProperty captureProperty
+    , liteav::TRTCVideoEncParam params
     , RECT rect
-    , trtc::TRTCVideoStreamType type) {
+    , liteav::TRTCVideoStreamType type) {
     sharing_rect_ = rect;
     enc_param_ = params;
     capture_property_ = captureProperty;
@@ -78,10 +78,10 @@ void TestScreenShareSelectScreen::init(trtc::TRTCScreenCaptureProperty capturePr
 }
 
 void TestScreenShareSelectScreen::updateScreenSharingParams(
-        trtc::TRTCScreenCaptureProperty captureProperty
-        ,trtc::TRTCVideoEncParam params
+        liteav::TRTCScreenCaptureProperty captureProperty
+        ,liteav::TRTCVideoEncParam params
         ,RECT rect
-        ,trtc::TRTCVideoStreamType type){
+        ,liteav::TRTCVideoStreamType type){
     sharing_rect_ = rect;
     enc_param_ = params;
     capture_property_ = captureProperty;
@@ -102,11 +102,11 @@ void TestScreenShareSelectScreen::initScreenSharingScreenSelections(){
     }
 
     int screen_capture_size = screen_capture_list_->getCount();
-    trtc::TRTCScreenCaptureSourceInfo screen_capture_source_info;
+    liteav::TRTCScreenCaptureSourceInfo screen_capture_source_info;
     int child_window_item_index = 0;
     for (int screen_index = 0; screen_index < screen_capture_size; screen_index++) {
         screen_capture_source_info = screen_capture_list_->getSourceInfo(screen_index);
-        if (screen_capture_source_info.type == trtc::TRTCScreenCaptureSourceTypeScreen) {
+        if (screen_capture_source_info.type == liteav::TRTCScreenCaptureSourceTypeScreen) {
             addScreenSharingWindowItem(screen_capture_source_info, child_window_item_index);
         }else{
             break;
@@ -148,7 +148,7 @@ void TestScreenShareSelectScreen::onScreenCaptureStoped(int reason) {
 }
 //============= ITRTCCloudCallback end =================//
 
-void TestScreenShareSelectScreen::addScreenSharingWindowItem(trtc::TRTCScreenCaptureSourceInfo screen_capture_source_info, int child_window_item_index)
+void TestScreenShareSelectScreen::addScreenSharingWindowItem(liteav::TRTCScreenCaptureSourceInfo screen_capture_source_info, int child_window_item_index)
 {
     ScreenShareSelectionItem* test_screensharing_item = new ScreenShareSelectionItem(screen_capture_source_info
         , ui_test_screen_share_select_screen_->widgetScreenWindows);

--- a/Mac/QTDemo/src/TestScreenShare/test_screen_share_select_screen.h
+++ b/Mac/QTDemo/src/TestScreenShare/test_screen_share_select_screen.h
@@ -37,8 +37,8 @@
 #include "test_user_video_group.h"
 
 #ifndef _WIN32
-    #define RECT trtc::RECT
-    #define SIZE trtc::SIZE
+    #define RECT liteav::RECT
+    #define SIZE liteav::SIZE
 #endif
 
 class TestScreenShareSelectScreen: public BaseDialog,public TrtcCloudCallbackDefaultImpl {
@@ -53,18 +53,18 @@ private:
     void resumeScreenCapture();
     void pauseScreenCapture();
     void releaseScreenCaptureSourceList();
-    void selectScreenCaptureTarget(trtc::TRTCScreenCaptureSourceInfo sourceInfo);
+    void selectScreenCaptureTarget(liteav::TRTCScreenCaptureSourceInfo sourceInfo);
     void initScreenCaptureSources();
     void initScreenSharingScreenSelections();
 public:
-    void init(trtc::TRTCScreenCaptureProperty captureProperty
-        , trtc::TRTCVideoEncParam params
+    void init(liteav::TRTCScreenCaptureProperty captureProperty
+        , liteav::TRTCVideoEncParam params
         , RECT rect
-        , trtc::TRTCVideoStreamType type);
-    void updateScreenSharingParams(trtc::TRTCScreenCaptureProperty captureProperty
-        , trtc::TRTCVideoEncParam params
+        , liteav::TRTCVideoStreamType type);
+    void updateScreenSharingParams(liteav::TRTCScreenCaptureProperty captureProperty
+        , liteav::TRTCVideoEncParam params
         , RECT rect
-        , trtc::TRTCVideoStreamType type);
+        , liteav::TRTCVideoStreamType type);
 
 private:
     //============= ITRTCCloudCallback start ===============//
@@ -76,7 +76,7 @@ private:
     void onScreenCaptureResumed(int reason) override;
     void onScreenCaptureStoped(int reason) override;
     //============= ITRTCCloudCallback end =================//
-    void addScreenSharingWindowItem(trtc::TRTCScreenCaptureSourceInfo screen_capture_source_info, 
+    void addScreenSharingWindowItem(liteav::TRTCScreenCaptureSourceInfo screen_capture_source_info, 
         int child_window_item_index);
 
     void closeEvent(QCloseEvent * closeEvent) override;
@@ -90,11 +90,11 @@ private slots:
 
 private:
     std::shared_ptr<TestUserVideoGroup> test_user_video_group_;
-    trtc::TRTCVideoStreamType stream_type_;
-    trtc::TRTCVideoEncParam enc_param_;
+    liteav::TRTCVideoStreamType stream_type_;
+    liteav::TRTCVideoEncParam enc_param_;
     RECT sharing_rect_;
-    trtc::TRTCScreenCaptureProperty capture_property_;
-    trtc::ITRTCScreenCaptureSourceList* screen_capture_list_ = nullptr;
+    liteav::TRTCScreenCaptureProperty capture_property_;
+    liteav::ITRTCScreenCaptureSourceList* screen_capture_list_ = nullptr;
     std::unique_ptr<Ui::TestScreenShareSelectScreenDialog> ui_test_screen_share_select_screen_;
 
     std::vector<ScreenShareSelectionItem*> all_sharing_items_;

--- a/Mac/QTDemo/src/TestScreenShare/test_screen_share_select_window.cpp
+++ b/Mac/QTDemo/src/TestScreenShare/test_screen_share_select_window.cpp
@@ -24,11 +24,11 @@ void TestScreenShareSelectWindow::initScreenSharingWindowSelections() {
     }
 
     int screen_capture_size = screen_capture_list_->getCount();
-    trtc::TRTCScreenCaptureSourceInfo screen_capture_source_info;
+    liteav::TRTCScreenCaptureSourceInfo screen_capture_source_info;
     int child_window_item_index = 0;
     for (int screen_index = 0; screen_index < screen_capture_size; screen_index++) {
         screen_capture_source_info = screen_capture_list_->getSourceInfo(screen_index);
-        if(screen_capture_source_info.type != trtc::TRTCScreenCaptureSourceTypeWindow){
+        if(screen_capture_source_info.type != liteav::TRTCScreenCaptureSourceTypeWindow){
             continue;
         }
 
@@ -46,7 +46,7 @@ void TestScreenShareSelectWindow::stopScreenSharing(){
 }
 
 void TestScreenShareSelectWindow::startScreenSharing(){
-    getTRTCShareInstance()->startScreenCapture(reinterpret_cast<trtc::TXView>(ui_screen_share_select_window_->screenSharedPreview->winId()),
+    getTRTCShareInstance()->startScreenCapture(reinterpret_cast<liteav::TXView>(ui_screen_share_select_window_->screenSharedPreview->winId()),
         stream_type_,
         &enc_param_);
 }
@@ -66,7 +66,7 @@ void TestScreenShareSelectWindow::releaseScreenCaptureSourceList(){
     }
 }
 
-void TestScreenShareSelectWindow::selectScreenCaptureTarget(trtc::TRTCScreenCaptureSourceInfo sourceInfo){
+void TestScreenShareSelectWindow::selectScreenCaptureTarget(liteav::TRTCScreenCaptureSourceInfo sourceInfo){
     getTRTCShareInstance()->selectScreenCaptureTarget(
         sourceInfo
         , sharing_rect_
@@ -128,7 +128,7 @@ void TestScreenShareSelectWindow::closeEvent(QCloseEvent * closeEvent){
     BaseDialog::closeEvent(closeEvent);
 }
 
-void TestScreenShareSelectWindow::addScreenSharingWindowItem(trtc::TRTCScreenCaptureSourceInfo screen_capture_source_info, int child_window_item_index) {
+void TestScreenShareSelectWindow::addScreenSharingWindowItem(liteav::TRTCScreenCaptureSourceInfo screen_capture_source_info, int child_window_item_index) {
     ScreenShareSelectionItem* test_screensharing_item = new ScreenShareSelectionItem(screen_capture_source_info
         , ui_screen_share_select_window_->scrrenSharingWindows);
 
@@ -151,10 +151,10 @@ void TestScreenShareSelectWindow::addScreenSharingWindowItem(trtc::TRTCScreenCap
     all_sharing_items_.push_back(test_screensharing_item);
 }
 
-void TestScreenShareSelectWindow::init(trtc::TRTCScreenCaptureProperty captureProperty
-    , trtc::TRTCVideoEncParam params
+void TestScreenShareSelectWindow::init(liteav::TRTCScreenCaptureProperty captureProperty
+    , liteav::TRTCVideoEncParam params
     , RECT rect
-    , trtc::TRTCVideoStreamType type) {
+    , liteav::TRTCVideoStreamType type) {
     sharing_rect_ = rect;
     enc_param_ = params;
     capture_property_ = captureProperty;
@@ -163,10 +163,10 @@ void TestScreenShareSelectWindow::init(trtc::TRTCScreenCaptureProperty capturePr
 }
 
 void TestScreenShareSelectWindow::updateScreenSharingParams(
-    trtc::TRTCScreenCaptureProperty& captureProperty
-    , trtc::TRTCVideoEncParam& params
+    liteav::TRTCScreenCaptureProperty& captureProperty
+    , liteav::TRTCVideoEncParam& params
     , RECT& rect
-    , trtc::TRTCVideoStreamType type) {
+    , liteav::TRTCVideoStreamType type) {
     sharing_rect_ = rect;
     enc_param_ = params;
     capture_property_ = captureProperty;

--- a/Mac/QTDemo/src/TestScreenShare/test_screen_share_select_window.h
+++ b/Mac/QTDemo/src/TestScreenShare/test_screen_share_select_window.h
@@ -37,8 +37,8 @@
 #include "test_user_video_group.h"
 
 #ifndef _WIN32
-    #define RECT trtc::RECT
-    #define SIZE trtc::SIZE
+    #define RECT liteav::RECT
+    #define SIZE liteav::SIZE
 #endif
 
 class TestScreenShareSelectWindow:
@@ -58,20 +58,20 @@ private:
     void pauseScreenCapture();
     void releaseScreenCaptureSourceList();
 
-    void selectScreenCaptureTarget(trtc::TRTCScreenCaptureSourceInfo sourceInfo);
+    void selectScreenCaptureTarget(liteav::TRTCScreenCaptureSourceInfo sourceInfo);
 
     void initScreenCaptureSources();
     void initScreenSharingWindowSelections();
 
 public:
-    void init(trtc::TRTCScreenCaptureProperty captureProperty
-        , trtc::TRTCVideoEncParam params
+    void init(liteav::TRTCScreenCaptureProperty captureProperty
+        , liteav::TRTCVideoEncParam params
         , RECT rect
-        , trtc::TRTCVideoStreamType type);
-    void updateScreenSharingParams(trtc::TRTCScreenCaptureProperty& captureProperty
-        , trtc::TRTCVideoEncParam& params
+        , liteav::TRTCVideoStreamType type);
+    void updateScreenSharingParams(liteav::TRTCScreenCaptureProperty& captureProperty
+        , liteav::TRTCVideoEncParam& params
         , RECT& rect
-        , trtc::TRTCVideoStreamType type);
+        , liteav::TRTCVideoStreamType type);
 
 private:
     //============= ITRTCCloudCallback start ===============//
@@ -84,7 +84,7 @@ private:
     void onScreenCaptureStoped(int reason) override;
     //============= ITRTCCloudCallback end =================//
 
-    void addScreenSharingWindowItem(trtc::TRTCScreenCaptureSourceInfo screen_capture_source_info
+    void addScreenSharingWindowItem(liteav::TRTCScreenCaptureSourceInfo screen_capture_source_info
         , int child_window_item_index);
     void closeEvent(QCloseEvent * closeEvent) override;
     void exitScreenSharing();
@@ -98,11 +98,11 @@ private slots:
 private:
     std::unique_ptr<Ui::TestScreenShareSelectWindowDialog> ui_screen_share_select_window_;
     std::shared_ptr<TestUserVideoGroup> test_user_video_group_;
-    trtc::TRTCVideoStreamType stream_type_;
-    trtc::TRTCVideoEncParam enc_param_;
+    liteav::TRTCVideoStreamType stream_type_;
+    liteav::TRTCVideoEncParam enc_param_;
     RECT sharing_rect_;
-    trtc::TRTCScreenCaptureProperty capture_property_;
-    trtc::ITRTCScreenCaptureSourceList* screen_capture_list_ = nullptr;
+    liteav::TRTCScreenCaptureProperty capture_property_;
+    liteav::ITRTCScreenCaptureSourceList* screen_capture_list_ = nullptr;
 
     std::vector<ScreenShareSelectionItem*> all_sharing_items_;
     ScreenShareSelectionItem*  selected_sharing_source_item_ = nullptr;

--- a/Mac/QTDemo/src/TestScreenShare/test_screen_share_setting.cpp
+++ b/Mac/QTDemo/src/TestScreenShare/test_screen_share_setting.cpp
@@ -19,13 +19,13 @@ void TestScreenShareSetting::setSubStreamMixVolume(int volume) {
     getTRTCShareInstance()->setSubStreamMixVolume(volume);
 }
 
-void TestScreenShareSetting::setSubStreamEncoderParam(trtc::TRTCVideoStreamType streamType, trtc::TRTCVideoEncParam & videoEncParam){
+void TestScreenShareSetting::setSubStreamEncoderParam(liteav::TRTCVideoStreamType streamType, liteav::TRTCVideoEncParam & videoEncParam){
     getTRTCShareInstance()->setSubStreamEncoderParam(videoEncParam);
 }
 
 void TestScreenShareSetting::updateScreenSharingParams() {
 
-    trtc::TRTCVideoEncParam video_enc_param;
+    liteav::TRTCVideoEncParam video_enc_param;
     video_enc_param.enableAdjustRes = enable_adjustres_;
     video_enc_param.minVideoBitrate = min_video_bitrate_;
     video_enc_param.resMode = res_mode_;
@@ -36,7 +36,7 @@ void TestScreenShareSetting::updateScreenSharingParams() {
     setSubStreamEncoderParam(video_stream_type, video_enc_param);
     setSubStreamMixVolume(mix_volume);
 
-    trtc::TRTCScreenCaptureProperty property;
+    liteav::TRTCScreenCaptureProperty property;
     property.enableCaptureMouse = enable_capturemouse_;
     property.enableHighLight = enable_highlight_;
     property.enableHighPerformance = enable_high_performance;
@@ -59,8 +59,8 @@ void TestScreenShareSetting::updateScreenSharingParams() {
 void TestScreenShareSetting::configViewParams(){
 
     video_resolution_ = indexConvertToVideoResolution(ui_screen_share_setting_->comBVideoResolution->currentIndex());
-    res_mode_ = static_cast<trtc::TRTCVideoResolutionMode>(ui_screen_share_setting_->comBResMode->currentIndex());
-    video_stream_type = ui_screen_share_setting_->comBPushStreamMode->currentIndex() == 0?trtc::TRTCVideoStreamTypeSub:trtc::TRTCVideoStreamTypeBig;
+    res_mode_ = static_cast<liteav::TRTCVideoResolutionMode>(ui_screen_share_setting_->comBResMode->currentIndex());
+    video_stream_type = ui_screen_share_setting_->comBPushStreamMode->currentIndex() == 0?liteav::TRTCVideoStreamTypeSub:liteav::TRTCVideoStreamTypeBig;
     mix_volume = ui_screen_share_setting_->sliderScreenCaptureMixVolume->value();
 
     videofps_ = ui_screen_share_setting_->lineEtvideoFps->text().toUInt();
@@ -78,20 +78,20 @@ void TestScreenShareSetting::configViewParams(){
     capture_rect_.right = ui_screen_share_setting_->lineEtRight->text().toUInt();
 }
 
-trtc::TRTCVideoResolution TestScreenShareSetting::indexConvertToVideoResolution(int index){
+liteav::TRTCVideoResolution TestScreenShareSetting::indexConvertToVideoResolution(int index){
     if(index < 4){
-        return static_cast<trtc::TRTCVideoResolution> (trtc::TRTCVideoResolution_120_120+ index * 2);
+        return static_cast<liteav::TRTCVideoResolution> (liteav::TRTCVideoResolution_120_120+ index * 2);
     }
 
     if(index < 12){
-        return static_cast<trtc::TRTCVideoResolution> (trtc::TRTCVideoResolution_160_120+ (index-4) * 2);
+        return static_cast<liteav::TRTCVideoResolution> (liteav::TRTCVideoResolution_160_120+ (index-4) * 2);
     }
 
     if(index < 20){
-        return static_cast<trtc::TRTCVideoResolution> (trtc::TRTCVideoResolution_160_90+ (index - 12) * 2);
+        return static_cast<liteav::TRTCVideoResolution> (liteav::TRTCVideoResolution_160_90+ (index - 12) * 2);
     }
 
-    return trtc::TRTCVideoResolution_1280_720;
+    return liteav::TRTCVideoResolution_1280_720;
 }
 
 void TestScreenShareSetting::closeEvent(QCloseEvent *event)
@@ -115,7 +115,7 @@ void TestScreenShareSetting::on_btSharingAllScreen_clicked(){
 
     configViewParams();
 
-    trtc::TRTCVideoEncParam param;
+    liteav::TRTCVideoEncParam param;
     param.enableAdjustRes = enable_adjustres_;
     param.minVideoBitrate = min_video_bitrate_;
     param.resMode = res_mode_;
@@ -123,7 +123,7 @@ void TestScreenShareSetting::on_btSharingAllScreen_clicked(){
     param.videoFps = videofps_;
     param.videoResolution = video_resolution_;
 
-    trtc::TRTCScreenCaptureProperty property;
+    liteav::TRTCScreenCaptureProperty property;
     property.enableCaptureMouse = enable_capturemouse_;
     property.enableHighLight = enable_highlight_;
     property.enableHighPerformance = enable_high_performance;
@@ -138,7 +138,7 @@ void TestScreenShareSetting::on_btSharingSelectedWindow_clicked(){
 
     configViewParams();
 
-    trtc::TRTCVideoEncParam param;
+    liteav::TRTCVideoEncParam param;
     param.enableAdjustRes = enable_adjustres_;
     param.minVideoBitrate = min_video_bitrate_;
     param.resMode = res_mode_;
@@ -146,7 +146,7 @@ void TestScreenShareSetting::on_btSharingSelectedWindow_clicked(){
     param.videoFps = videofps_;
     param.videoResolution = video_resolution_;
 
-    trtc::TRTCScreenCaptureProperty property;
+    liteav::TRTCScreenCaptureProperty property;
     property.enableCaptureMouse = enable_capturemouse_;
     property.enableHighLight = enable_highlight_;
     property.enableHighPerformance = enable_high_performance;

--- a/Mac/QTDemo/src/TestScreenShare/test_screen_share_setting.h
+++ b/Mac/QTDemo/src/TestScreenShare/test_screen_share_setting.h
@@ -36,7 +36,7 @@ public:
 private :
     void updateScreenSharingParams();
     void setSubStreamMixVolume(int volume);
-    void setSubStreamEncoderParam(trtc::TRTCVideoStreamType streamType,trtc::TRTCVideoEncParam& videoEncParam);
+    void setSubStreamEncoderParam(liteav::TRTCVideoStreamType streamType,liteav::TRTCVideoEncParam& videoEncParam);
 private slots:
     void on_btUpdateScreenSharing_clicked();
     void on_btSharingAllScreen_clicked();
@@ -45,7 +45,7 @@ private slots:
 
 private:
     void configViewParams();
-    inline trtc::TRTCVideoResolution indexConvertToVideoResolution(int index);
+    inline liteav::TRTCVideoResolution indexConvertToVideoResolution(int index);
     void retranslateUi() override;
 public:
     void closeEvent(QCloseEvent *event) override;
@@ -56,9 +56,9 @@ private:
     TestScreenShareSelectScreen test_screensharing_withscreen;
     TestScreenShareSelectWindow test_screensharing_withwindow;
 
-    trtc::TRTCVideoResolution video_resolution_ = trtc::TRTCVideoResolution_1280_720;
-    trtc::TRTCVideoResolutionMode res_mode_ = trtc::TRTCVideoResolutionModeLandscape;
-    trtc::TRTCVideoStreamType video_stream_type = trtc::TRTCVideoStreamTypeSub;
+    liteav::TRTCVideoResolution video_resolution_ = liteav::TRTCVideoResolution_1280_720;
+    liteav::TRTCVideoResolutionMode res_mode_ = liteav::TRTCVideoResolutionModeLandscape;
+    liteav::TRTCVideoStreamType video_stream_type = liteav::TRTCVideoStreamTypeSub;
     uint32_t mix_volume = 50;
     uint32_t videofps_ = 15;
     uint32_t video_bitrate_ = 1200;

--- a/Mac/QTDemo/src/TestSubCloudSetting/test_subcloud_setting.cpp
+++ b/Mac/QTDemo/src/TestSubCloudSetting/test_subcloud_setting.cpp
@@ -13,11 +13,11 @@ TestSubCloudSetting::~TestSubCloudSetting(){
     exitSubCloudRoom();
 }
 
-void TestSubCloudSetting::enterSubCloudRoom(uint32_t roomId, std::string userId, trtc::TRTCAppScene appScene) {
+void TestSubCloudSetting::enterSubCloudRoom(uint32_t roomId, std::string userId, liteav::TRTCAppScene appScene) {
     sub_cloud_ = getTRTCShareInstance()->createSubCloud();
 
-    trtc::TRTCParams params;
-    params.role = trtc::TRTCRoleAudience;
+    liteav::TRTCParams params;
+    params.role = liteav::TRTCRoleAudience;
     room_id_ = roomId;
     params.roomId = room_id_;
     params.sdkAppId = SDKAppID;
@@ -100,7 +100,7 @@ void TestSubCloudSetting::onRemoteUserLeaveRoom(const char *userId, int reason){
     test_user_video_group_->onSubRoomUserLeaveRoom(room_id_, userId);
 }
 
-void TestSubCloudSetting::onUserVoiceVolume(trtc::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) {
+void TestSubCloudSetting::onUserVoiceVolume(liteav::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) {
     test_user_video_group_->handleUserVolume(userVolumes, userVolumesCount, totalVolume);
 }
 

--- a/Mac/QTDemo/src/TestSubCloudSetting/test_subcloud_setting.h
+++ b/Mac/QTDemo/src/TestSubCloudSetting/test_subcloud_setting.h
@@ -47,7 +47,7 @@ public:
     explicit TestSubCloudSetting(std::shared_ptr<TestUserVideoGroup> testUserVideoGroup);
     ~TestSubCloudSetting();
 
-    void enterSubCloudRoom(uint32_t roomId, std::string userId, trtc::TRTCAppScene appScene);
+    void enterSubCloudRoom(uint32_t roomId, std::string userId, liteav::TRTCAppScene appScene);
     void exitSubCloudRoom();
 
 public slots:
@@ -61,14 +61,14 @@ private:
     void onUserAudioAvailable(const char* userId, bool available) override;
     void onRemoteUserEnterRoom (const char *userId) override;
     void onRemoteUserLeaveRoom (const char *userId, int reason) override;
-    void onUserVoiceVolume(trtc::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) override;
+    void onUserVoiceVolume(liteav::TRTCVolumeInfo* userVolumes, uint32_t userVolumesCount, uint32_t totalVolume) override;
     //============= ITRTCCloudCallback end =================//
 signals:
     void onEnterSubRoom(bool result);
     void onExitSubRoom();
 
 private:
-    trtc::ITRTCCloud *sub_cloud_ = nullptr;
+    liteav::ITRTCCloud *sub_cloud_ = nullptr;
     std::shared_ptr<TestUserVideoGroup> test_user_video_group_;
 
     uint32_t room_id_;

--- a/Mac/QTDemo/src/TestVideoDetect/test_video_detect.cpp
+++ b/Mac/QTDemo/src/TestVideoDetect/test_video_detect.cpp
@@ -69,17 +69,17 @@ void TestVideoDetect::refreshCameraDevices()
         return;
     }
     qvector_device_info_camera_.clear();
-    trtc::ITXDeviceCollection *device_collection_camera = tx_device_manager_->getDevicesList(trtc::TXMediaDeviceType::TXMediaDeviceTypeCamera);
+    liteav::ITXDeviceCollection *device_collection_camera = tx_device_manager_->getDevicesList(liteav::TXMediaDeviceType::TXMediaDeviceTypeCamera);
     uint32_t camera_device_count = device_collection_camera->getCount();
     if(camera_device_count != 0) {
 
-        trtc::ITXDeviceInfo *current_camera_device = tx_device_manager_->getCurrentDevice(trtc::TXMediaDeviceType::TXMediaDeviceTypeCamera);
+        liteav::ITXDeviceInfo *current_camera_device = tx_device_manager_->getCurrentDevice(liteav::TXMediaDeviceType::TXMediaDeviceTypeCamera);
         ui_video_test_->comboBoxCameraDevices->clear();
         uint32_t current_selected_camera_device_index = 0;
 
         for(uint32_t index = 0; index < camera_device_count; index++) {
 
-            const DeviceInfoItem item = DeviceInfoItem(device_collection_camera->getDeviceName(index), device_collection_camera->getDevicePID(index), trtc::TXMediaDeviceType::TXMediaDeviceTypeCamera);
+            const DeviceInfoItem item = DeviceInfoItem(device_collection_camera->getDeviceName(index), device_collection_camera->getDevicePID(index), liteav::TXMediaDeviceType::TXMediaDeviceTypeCamera);
             qvector_device_info_camera_.append(item);
             ui_video_test_->comboBoxCameraDevices->addItem(QString::fromStdString(item.device_name_));
 

--- a/Mac/QTDemo/src/TestVideoDetect/test_video_detect.h
+++ b/Mac/QTDemo/src/TestVideoDetect/test_video_detect.h
@@ -62,17 +62,17 @@ private:
 
     std::string device_name_;
     std::string device_id_;
-    trtc::TXMediaDeviceType device_type_;
+    liteav::TXMediaDeviceType device_type_;
 
     DeviceInfoItem(){}
-    DeviceInfoItem(std::string device_name, std::string device_id, trtc::TXMediaDeviceType device_type) :
+    DeviceInfoItem(std::string device_name, std::string device_id, liteav::TXMediaDeviceType device_type) :
             device_name_(device_name), device_id_(device_id), device_type_(device_type) {}
 
     };
 
 private:
     std::unique_ptr<Ui::TestVideoDetectDialog> ui_video_test_;
-    trtc::ITXDeviceManager *tx_device_manager_;
+    liteav::ITXDeviceManager *tx_device_manager_;
     QVector<DeviceInfoItem> qvector_device_info_camera_;
     bool device_info_ready_;
     bool camera_test_started_ = false;

--- a/Mac/QTDemo/src/TestVideoSetting/test_video_setting.cpp
+++ b/Mac/QTDemo/src/TestVideoSetting/test_video_setting.cpp
@@ -18,8 +18,8 @@ TestVideoSetting::~TestVideoSetting() {
 
 void TestVideoSetting::updateVideoEncoderParams()
 {
-    trtc::TRTCVideoResolution resolution  = video_resolution_hashmap_.value(ui_video_setting_->comboBoxVideoResolution->currentIndex());
-    trtc::TRTCVideoResolutionMode resolution_mode = (ui_video_setting_->comboBoxResolutionMode->currentIndex() == 0)? trtc::TRTCVideoResolutionMode::TRTCVideoResolutionModeLandscape : trtc::TRTCVideoResolutionMode::TRTCVideoResolutionModePortrait;
+    liteav::TRTCVideoResolution resolution  = video_resolution_hashmap_.value(ui_video_setting_->comboBoxVideoResolution->currentIndex());
+    liteav::TRTCVideoResolutionMode resolution_mode = (ui_video_setting_->comboBoxResolutionMode->currentIndex() == 0)? liteav::TRTCVideoResolutionMode::TRTCVideoResolutionModeLandscape : liteav::TRTCVideoResolutionMode::TRTCVideoResolutionModePortrait;
     uint32_t video_fps = (ui_video_setting_->comboBoxVideoFps->currentIndex()) == 0 ? 15 : 20;
     uint32_t bitrate = (uint32_t)(ui_video_setting_->horizontalSliderVideoBitrate->value());
     bool enable_adjust_resolution = ui_video_setting_->checkBoxEnableAdjustRes->isChecked();
@@ -29,7 +29,7 @@ void TestVideoSetting::updateVideoEncoderParams()
     bitrate_text = bitrate_text.append(QString::fromUtf8("kbps: "));
     ui_video_setting_->labelBitrateDesc->setText(bitrate_text);
 
-    trtc::TRTCVideoEncParam param;
+    liteav::TRTCVideoEncParam param;
     param.resMode = resolution_mode;
     param.videoResolution = resolution;
     param.videoBitrate = bitrate;
@@ -65,34 +65,34 @@ void TestVideoSetting::on_checkBoxEnableAdjustRes_stateChanged(int arg1)
 
 void TestVideoSetting::on_checkBoxEnableEncSmallVideoStream_stateChanged(int arg1)
 {
-    trtc::TRTCVideoEncParam param;
-    param.resMode = (ui_video_setting_->comboBoxResolutionMode->currentIndex() == 0)? trtc::TRTCVideoResolutionMode::TRTCVideoResolutionModeLandscape : trtc::TRTCVideoResolutionMode::TRTCVideoResolutionModePortrait;
-    param.videoResolution = trtc::TRTCVideoResolution_640_360;
+    liteav::TRTCVideoEncParam param;
+    param.resMode = (ui_video_setting_->comboBoxResolutionMode->currentIndex() == 0)? liteav::TRTCVideoResolutionMode::TRTCVideoResolutionModeLandscape : liteav::TRTCVideoResolutionMode::TRTCVideoResolutionModePortrait;
+    param.videoResolution = liteav::TRTCVideoResolution_640_360;
     trtccloud_->enableSmallVideoStream(ui_video_setting_->checkBoxEnableEncSmallVideoStream->isChecked(), param);
 }
 
 void TestVideoSetting::setupVideoResolutionMap()
 {
-    video_resolution_hashmap_.insert(0, trtc::TRTCVideoResolution_120_120);
-    video_resolution_hashmap_.insert(1, trtc::TRTCVideoResolution_160_160);
-    video_resolution_hashmap_.insert(2, trtc::TRTCVideoResolution_270_270);
-    video_resolution_hashmap_.insert(3, trtc::TRTCVideoResolution_480_480);
-    video_resolution_hashmap_.insert(4, trtc::TRTCVideoResolution_160_120);
-    video_resolution_hashmap_.insert(5, trtc::TRTCVideoResolution_240_180);
-    video_resolution_hashmap_.insert(6, trtc::TRTCVideoResolution_280_210);
-    video_resolution_hashmap_.insert(7, trtc::TRTCVideoResolution_320_240);
-    video_resolution_hashmap_.insert(8, trtc::TRTCVideoResolution_400_300);
-    video_resolution_hashmap_.insert(9, trtc::TRTCVideoResolution_480_360);
-    video_resolution_hashmap_.insert(10, trtc::TRTCVideoResolution_640_480);
-    video_resolution_hashmap_.insert(11, trtc::TRTCVideoResolution_960_720);
-    video_resolution_hashmap_.insert(12, trtc::TRTCVideoResolution_160_90);
-    video_resolution_hashmap_.insert(13, trtc::TRTCVideoResolution_256_144);
-    video_resolution_hashmap_.insert(14, trtc::TRTCVideoResolution_320_180);
-    video_resolution_hashmap_.insert(15, trtc::TRTCVideoResolution_480_270);
-    video_resolution_hashmap_.insert(16, trtc::TRTCVideoResolution_640_360);
-    video_resolution_hashmap_.insert(17, trtc::TRTCVideoResolution_960_540);
-    video_resolution_hashmap_.insert(18, trtc::TRTCVideoResolution_1280_720);
-    video_resolution_hashmap_.insert(19, trtc::TRTCVideoResolution_1920_1080);
+    video_resolution_hashmap_.insert(0, liteav::TRTCVideoResolution_120_120);
+    video_resolution_hashmap_.insert(1, liteav::TRTCVideoResolution_160_160);
+    video_resolution_hashmap_.insert(2, liteav::TRTCVideoResolution_270_270);
+    video_resolution_hashmap_.insert(3, liteav::TRTCVideoResolution_480_480);
+    video_resolution_hashmap_.insert(4, liteav::TRTCVideoResolution_160_120);
+    video_resolution_hashmap_.insert(5, liteav::TRTCVideoResolution_240_180);
+    video_resolution_hashmap_.insert(6, liteav::TRTCVideoResolution_280_210);
+    video_resolution_hashmap_.insert(7, liteav::TRTCVideoResolution_320_240);
+    video_resolution_hashmap_.insert(8, liteav::TRTCVideoResolution_400_300);
+    video_resolution_hashmap_.insert(9, liteav::TRTCVideoResolution_480_360);
+    video_resolution_hashmap_.insert(10, liteav::TRTCVideoResolution_640_480);
+    video_resolution_hashmap_.insert(11, liteav::TRTCVideoResolution_960_720);
+    video_resolution_hashmap_.insert(12, liteav::TRTCVideoResolution_160_90);
+    video_resolution_hashmap_.insert(13, liteav::TRTCVideoResolution_256_144);
+    video_resolution_hashmap_.insert(14, liteav::TRTCVideoResolution_320_180);
+    video_resolution_hashmap_.insert(15, liteav::TRTCVideoResolution_480_270);
+    video_resolution_hashmap_.insert(16, liteav::TRTCVideoResolution_640_360);
+    video_resolution_hashmap_.insert(17, liteav::TRTCVideoResolution_960_540);
+    video_resolution_hashmap_.insert(18, liteav::TRTCVideoResolution_1280_720);
+    video_resolution_hashmap_.insert(19, liteav::TRTCVideoResolution_1920_1080);
 }
 
 void TestVideoSetting::retranslateUi() {

--- a/Mac/QTDemo/src/TestVideoSetting/test_video_setting.h
+++ b/Mac/QTDemo/src/TestVideoSetting/test_video_setting.h
@@ -57,8 +57,8 @@ private:
 
 private:
     std::unique_ptr<Ui::TestVideoSettingDialog> ui_video_setting_;
-    QHash<int, trtc::TRTCVideoResolution> video_resolution_hashmap_;
-    trtc::ITRTCCloud *trtccloud_;
+    QHash<int, liteav::TRTCVideoResolution> video_resolution_hashmap_;
+    liteav::ITRTCCloud *trtccloud_;
 };
 
 #endif // TESTVIDEOSETTING_H

--- a/Mac/QTDemo/src/Util/trtc_cloud_callback_default_impl.h
+++ b/Mac/QTDemo/src/Util/trtc_cloud_callback_default_impl.h
@@ -5,7 +5,7 @@
 
 #include "ITRTCCloud.h"
 
-class TrtcCloudCallbackDefaultImpl:public trtc::ITRTCCloudCallback
+class TrtcCloudCallbackDefaultImpl:public liteav::ITRTCCloudCallback
 {
 public:
     virtual void onWarning(TXLiteAVWarning warningCode, const char* warningMsg, void* extraInfo) override{

--- a/Mac/QTDemo/src/Util/win/cdnplayer/tx_liveplayer_proxy.cpp
+++ b/Mac/QTDemo/src/Util/win/cdnplayer/tx_liveplayer_proxy.cpp
@@ -36,7 +36,7 @@ void TXLivePlayerProxy::resume()
 
 void TXLivePlayerProxy::setRenderFrame(void* handle)
 {
-    live_player_->setRenderFrame(reinterpret_cast<trtc::TXView>(handle));
+    live_player_->setRenderFrame(reinterpret_cast<liteav::TXView>(handle));
 }
 
 void TXLivePlayerProxy::setRenderMode(TXLivePlayerProxy_RenderMode render_mode)

--- a/Mac/QTDemo/src/main_window.cpp
+++ b/Mac/QTDemo/src/main_window.cpp
@@ -97,16 +97,16 @@ void MainWindow::onExitRoom(int reason) {
 //============= ITRTCCloudCallback end===================//
 
 void MainWindow::on_enterRoomButton_clicked() {
-    trtc::TRTCAppScene app_scene = getCurrentSelectedAppScene();
+    liteav::TRTCAppScene app_scene = getCurrentSelectedAppScene();
     uint32_t room_id = ui_mainwindow_->roomNumLineEdit->text().toUInt();
     std::string user_id = ui_mainwindow_->userIdLineEdit->text().toStdString();
-    if (app_scene == trtc::TRTCAppScene::TRTCAppSceneLIVE || app_scene == trtc::TRTCAppScene::TRTCAppSceneVoiceChatRoom) {
+    if (app_scene == liteav::TRTCAppScene::TRTCAppSceneLIVE || app_scene == liteav::TRTCAppScene::TRTCAppSceneVoiceChatRoom) {
         int selelct_role_index = ui_mainwindow_->userRoleComB->currentIndex();
         if (selelct_role_index == -1){
             QMessageBox::warning(NULL, "Failed to enter the room", "You must select a role in live streaming scenarios.");
             return;
         }
-        trtc::TRTCRoleType role_type = getCurrentSelectedRoleType();
+        liteav::TRTCRoleType role_type = getCurrentSelectedRoleType();
         test_base_scene_.enterRoom(room_id, user_id, app_scene, role_type);
     } else {
         test_base_scene_.enterRoom(room_id, user_id, app_scene);
@@ -185,7 +185,7 @@ void MainWindow::on_btnEnterSubRoom_clicked(){
             QMessageBox::warning(this, "Failed to enter the sub-room", "Enter a sub-room ID.", QMessageBox::Ok);
             return;
         }
-        trtc::TRTCAppScene app_scene = getCurrentSelectedAppScene();
+        liteav::TRTCAppScene app_scene = getCurrentSelectedAppScene();
         uint32_t room_id = ui_mainwindow_->lineetSubRoomId->text().toUInt();
         std::string user_id = ui_mainwindow_->userIdLineEdit->text().toStdString();
         test_subcloud_setting_.enterSubCloudRoom(room_id, user_id, app_scene);
@@ -227,13 +227,13 @@ void MainWindow::on_roomNumLineEdit_textChanged(const QString &roomNum) {
 void MainWindow::on_appSceneComboBox_currentIndexChanged(int index) {
     switch (index)
     {
-    case trtc::TRTCAppScene::TRTCAppSceneAudioCall:
-    case trtc::TRTCAppScene::TRTCAppSceneVideoCall:
+    case liteav::TRTCAppScene::TRTCAppSceneAudioCall:
+    case liteav::TRTCAppScene::TRTCAppSceneVideoCall:
         ui_mainwindow_->userRoleComB->setEnabled(false);
         ui_mainwindow_->userRoleComB->setCurrentIndex(-1);
         break;
-    case trtc::TRTCAppScene::TRTCAppSceneVoiceChatRoom:
-    case trtc::TRTCAppScene::TRTCAppSceneLIVE:
+    case liteav::TRTCAppScene::TRTCAppSceneVoiceChatRoom:
+    case liteav::TRTCAppScene::TRTCAppSceneLIVE:
         ui_mainwindow_->userRoleComB->setEnabled(true);
         break;
     default:
@@ -243,10 +243,10 @@ void MainWindow::on_appSceneComboBox_currentIndexChanged(int index) {
 
 void MainWindow::on_userRoleComB_currentIndexChanged(int index){
     if(room_entered_) {
-        trtc::TRTCAppScene app_scene = getCurrentSelectedAppScene();
+        liteav::TRTCAppScene app_scene = getCurrentSelectedAppScene();
 
         // Only live streaming scenarios support role switching
-        if (app_scene == trtc::TRTCAppScene::TRTCAppSceneLIVE || app_scene == trtc::TRTCAppScene::TRTCAppSceneVoiceChatRoom) {
+        if (app_scene == liteav::TRTCAppScene::TRTCAppSceneLIVE || app_scene == liteav::TRTCAppScene::TRTCAppSceneVoiceChatRoom) {
             test_base_scene_.switchRole(getCurrentSelectedRoleType());
         }
     }
@@ -293,22 +293,22 @@ void MainWindow::updateModuleDialogStatus(bool isEnteredRoom)
     }
 }
 
-trtc::TRTCAppScene MainWindow::getCurrentSelectedAppScene()
+liteav::TRTCAppScene MainWindow::getCurrentSelectedAppScene()
 {
-    trtc::TRTCAppScene appScene = trtc::TRTCAppScene::TRTCAppSceneVideoCall;
+    liteav::TRTCAppScene appScene = liteav::TRTCAppScene::TRTCAppSceneVideoCall;
     int current_index = ui_mainwindow_->appSceneComboBox->currentIndex();
     switch(current_index) {
     case 0:
-        appScene = trtc::TRTCAppScene::TRTCAppSceneVideoCall;
+        appScene = liteav::TRTCAppScene::TRTCAppSceneVideoCall;
         break;
     case 1:
-        appScene = trtc::TRTCAppScene::TRTCAppSceneLIVE;
+        appScene = liteav::TRTCAppScene::TRTCAppSceneLIVE;
         break;
     case 2:
-        appScene = trtc::TRTCAppScene::TRTCAppSceneAudioCall;
+        appScene = liteav::TRTCAppScene::TRTCAppSceneAudioCall;
         break;
     case 3:
-        appScene = trtc::TRTCAppScene::TRTCAppSceneVoiceChatRoom;
+        appScene = liteav::TRTCAppScene::TRTCAppSceneVoiceChatRoom;
         break;
     default:
         break;
@@ -316,9 +316,9 @@ trtc::TRTCAppScene MainWindow::getCurrentSelectedAppScene()
     return appScene;
 }
 
-trtc::TRTCRoleType MainWindow::getCurrentSelectedRoleType()
+liteav::TRTCRoleType MainWindow::getCurrentSelectedRoleType()
 {
-    return ui_mainwindow_->userRoleComB->currentIndex() != 0? trtc::TRTCRoleType::TRTCRoleAudience : trtc::TRTCRoleType::TRTCRoleAnchor;
+    return ui_mainwindow_->userRoleComB->currentIndex() != 0? liteav::TRTCRoleType::TRTCRoleAudience : liteav::TRTCRoleType::TRTCRoleAnchor;
 }
 
 void MainWindow::on_pushButtonDeviceManager_clicked()

--- a/Mac/QTDemo/src/main_window.h
+++ b/Mac/QTDemo/src/main_window.h
@@ -110,8 +110,8 @@ public:
 private:
     void updateModuleButtonStatus(bool isEnteredRoom);
     void updateModuleDialogStatus(bool isEnteredRoom);
-    trtc::TRTCAppScene getCurrentSelectedAppScene();
-    trtc::TRTCRoleType getCurrentSelectedRoleType();
+    liteav::TRTCAppScene getCurrentSelectedAppScene();
+    liteav::TRTCRoleType getCurrentSelectedRoleType();
     void changeLanguage(int language);
     void updateDynamicTextUI();
 private:


### PR DESCRIPTION
由于新架构的 TRTC SDK 较老版本有如下变化：
 1. 新架构 TRTC SDK 库依赖的系统库有所变化；
 2. 新版本 TRTC SDK 将 TXFFMpeg 和 TXSoundTouch 作为动态库进行依赖；
 3.  新架构使用了 liteav 命名空间，且已经不兼容老的 trtc 命名空间了；
 因此 QT 项目设置依赖时和老版本有所不同，本次主要变更Mac端使用 QT 集成 TRTC SDK 时一些配置和依赖，以及将代码中的 trtc 命名空间变为 liteav 命名空间。